### PR TITLE
ci: cut publish pipeline from ~90min to ~25min (self-hosted smoke, tiered polling)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,53 +29,68 @@ env:
 
 jobs:
   validate:
-    name: Validate and Test
-    runs-on: ubuntu-latest
-    # A cold GitHub runner was canceled by the 45-minute limit near the end of
-    # the approved CPU matrix; retain a finite bound with enough headroom.
-    timeout-minutes: 90
+    name: Release smoke validation (self-hosted)
+    runs-on: [self-hosted, release]
+    timeout-minutes: 30
+    # Velocity redesign (post-0.24.1): a v* tag always points at a master
+    # merge commit whose constituent commits already passed full PR CI
+    # (ci.yml + mathematical-correctness.yml). Re-running the complete
+    # test/clippy/docs matrix here duplicated roughly an hour on a cold
+    # GitHub runner. This job is now a fast smoke gate on the dedicated
+    # self-hosted release runner: formatting, version and metadata authority,
+    # catalog determinism, publish-order/tier safety, and a compile check.
+    # The heavy matrix remains enforced at the PR gate; do not reintroduce
+    # cargo test / cargo clippy here (pinned by verify-publish-test-scope.py).
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Keep the persistent target/ directory on the dedicated runner so
+          # repeat validations stay warm between releases.
+          clean: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.97.1
         with:
-          components: rustfmt, clippy
+          components: rustfmt
 
-      - name: Cache cargo dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Resolve release version
+        id: release
+        run: |
+          INPUT_VERSION="${{ github.event.inputs.version }}"
+          VERSION="${INPUT_VERSION:-${GITHUB_REF_NAME#v}}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Run clippy
-        # Tagged 0.24.0 test code contains four pre-existing warnings: three
-        # needless_range_loop findings in amari-core/src/generic.rs and one
-        # collapsible_match in amari-enumerative/tests/classical_problems.rs.
-        # Keep normal targets warning-denied, then compile every target while
-        # allowing only those test-only lints. Fix forward on develop.
-        run: |
-          cargo clippy --workspace --all-features -- -D warnings
-          cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::needless_range_loop -A clippy::collapsible_match
+      - name: Verify synchronized versions
+        run: scripts/version-sync.sh verify ${{ steps.release.outputs.version }}
 
-      - name: Verify publish test scope
+      - name: Verify release metadata
+        run: python3 scripts/verify-release-metadata.py ${{ steps.release.outputs.version }}
+
+      - name: Verify catalog determinism
+        run: |
+          cargo run -p amari-discovery --example generate_catalog -- .
+          scripts/generate-discovery-wasm-surface.sh
+          git diff --exit-code
+
+      - name: Verify publish order and tiers
+        run: python3 scripts/verify-publish-order.py
+
+      - name: Verify publish workflow policy
         run: python3 scripts/verify-publish-test-scope.py
 
-      - name: Run approved CPU release tests
-        # The 0.24.0 headless validator explicitly excludes legacy amari-gpu
-        # runtime tests while retaining all-feature compilation through Clippy.
-        # GPU runtime restoration belongs to the planned 0.26.0 modernization.
-        run: |
-          cargo test --workspace --exclude amari-gpu
-          cargo test -p amari-discovery --all-features
-          cargo test -p amari-holographic --all-features
+      - name: Verify workflow crate coverage
+        run: scripts/verify-workflow-crates.sh
+
+      - name: Verify amari binary ownership
+        run: python3 scripts/verify-amari-binary-owner.py
+
+      - name: Compile workspace
+        run: cargo check --workspace --all-features
 
   publish-crates:
     name: Publish to crates.io
@@ -111,80 +126,96 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          # Publish in dependency order with delays for crates.io rate limiting
-          # IMPORTANT: New crates should be added before amari-measure, amari-wasm, amari-gpu, and amari
-          # See VERSION_MANAGEMENT.md for best practices
-          # Dependency order is critical! amari-functional and amari-topology must come
-          # before amari-gpu because amari-gpu has optional deps on them.
-          CRATES=(
-            "amari-core"
-            "amari-tropical"
-            "amari-dual"
-            "amari-network"
-            "amari-info-geom"
-            "amari-relativistic"
-            "amari-holographic"
-            "amari-fusion"
-            "amari-automata"
-            "amari-cgt"
-            "amari-surreal"
-            "amari-surcomplex"
-            "amari-enumerative"
-            "amari-flynn-macros"
-            "amari-flynn"
-            "amari-measure"
-            "amari-calculus"
-            "amari-functional"
-            "amari-topology"
-            "amari-probabilistic"
-            "amari-dynamics"
-            "amari-rewrite"
-            "amari-gpu"
+          set -euo pipefail
+          # Publish in dependency tiers. Crates within a tier do not depend on
+          # any other published crate in the same tier, so each tier boundary
+          # is the only point where crates.io indexing must be observed.
+          # Instead of fixed sleeps, poll the sparse index until the tier is
+          # visible (typically 10-30s). Tier structure is pinned by
+          # scripts/verify-publish-order.py against cargo metadata.
+          # IMPORTANT: add new crates to the earliest tier after all of their
+          # published internal dependencies; keep amari last (aggregate).
+          TIERS=(
+            "amari-core amari-cgt amari-flynn-macros amari-discovery-macros"
+            "amari-tropical amari-dual amari-info-geom amari-relativistic amari-holographic amari-surreal amari-enumerative amari-flynn"
+            "amari-network amari-fusion amari-automata amari-surcomplex amari-measure"
+            "amari-calculus amari-probabilistic amari-rewrite"
+            "amari-functional amari-topology"
+            "amari-dynamics amari-gpu"
             "amari-optimization"
-            "amari-discovery-macros"
             "amari-discovery"
             "amari"
           )
 
-          for crate in "${CRATES[@]}"; do
-            echo "Publishing $crate..."
-            if [ "$crate" != "amari" ]; then
-              cd "$crate"
+          sparse_index_url() {
+            local name="$1" len=${#1}
+            if [ "$len" -eq 1 ]; then
+              echo "https://index.crates.io/1/$name"
+            elif [ "$len" -eq 2 ]; then
+              echo "https://index.crates.io/2/$name"
+            elif [ "$len" -eq 3 ]; then
+              echo "https://index.crates.io/3/${name:0:1}/$name"
+            else
+              echo "https://index.crates.io/${name:0:2}/${name:2:2}/$name"
             fi
+          }
 
-            # Get the actual version from Cargo.toml (handle workspace versions)
-            if grep -q "^version.workspace = true" Cargo.toml; then
-              # Get version from workspace Cargo.toml [workspace.package] section
-              if [ "$crate" = "amari" ]; then
-                WORKSPACE_TOML="Cargo.toml"
-              else
-                WORKSPACE_TOML="../Cargo.toml"
+          version_published() {
+            curl -sf "$(sparse_index_url "$1")" | grep -q "\"vers\":\"$2\""
+          }
+
+          wait_for_index() {
+            local crate="$1" version="$2" deadline=$((SECONDS + 300))
+            echo "Waiting for $crate $version in the sparse index..."
+            until version_published "$crate" "$version"; do
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "Timed out waiting for $crate $version to index"
+                return 1
               fi
-              ACTUAL_VERSION=$(awk '/^\[workspace\.package\]/{f=1} f && /^version = /{print $NF; exit}' "$WORKSPACE_TOML" | sed 's/"//g' || echo "unknown")
+              sleep 10
+            done
+            echo "$crate $version is indexed"
+          }
+
+          resolve_version() {
+            local dir="$1"
+            if grep -q "^version.workspace = true" "$dir/Cargo.toml"; then
+              awk '/^\[workspace\.package\]/{f=1} f && /^version = /{print $NF; exit}' Cargo.toml | sed 's/"//g'
             else
-              # Get version from local Cargo.toml
-              ACTUAL_VERSION=$(grep "^version" Cargo.toml | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/' || echo "unknown")
+              grep "^version" "$dir/Cargo.toml" | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/'
             fi
-            INPUT_VERSION="${{ github.event.inputs.version }}"
-            TARGET_VERSION="${INPUT_VERSION:-$ACTUAL_VERSION}"
+          }
 
-            echo "Checking $crate version $TARGET_VERSION..."
+          INPUT_VERSION="${{ github.event.inputs.version }}"
 
-            # Check if already published
-            if cargo search "$crate" --limit 1 | grep -q "^$crate = \"$TARGET_VERSION\""; then
-              echo "$crate version $TARGET_VERSION already published, skipping..."
-            else
+          for tier in "${TIERS[@]}"; do
+            echo "=== Publishing tier: $tier ==="
+            JUST_PUBLISHED=()
+            for crate in $tier; do
+              dir="$crate"
+              [ "$crate" = "amari" ] && dir="."
+
+              ACTUAL_VERSION=$(resolve_version "$dir")
+              TARGET_VERSION="${INPUT_VERSION:-$ACTUAL_VERSION}"
+              echo "Checking $crate version $TARGET_VERSION..."
+
+              if version_published "$crate" "$TARGET_VERSION"; then
+                echo "$crate version $TARGET_VERSION already published, skipping..."
+                continue
+              fi
+
               echo "Verifying $crate version $TARGET_VERSION package..."
-              cargo publish --dry-run --allow-dirty
+              (cd "$dir" && cargo publish --dry-run --allow-dirty)
               echo "Publishing $crate version $TARGET_VERSION..."
-              cargo publish --allow-dirty
-              echo "Waiting for crates.io indexing and rate limit reset..."
-              sleep 45
-            fi
+              (cd "$dir" && cargo publish --allow-dirty)
+              JUST_PUBLISHED+=("$crate@$TARGET_VERSION")
+            done
 
-            if [ "$crate" != "amari" ]; then
-              cd ..
-            fi
+            # Dependent tiers resolve against the registry, so wait until
+            # every crate published in this tier is visible in the index.
+            for entry in ${JUST_PUBLISHED[@]+"${JUST_PUBLISHED[@]}"}; do
+              wait_for_index "${entry%@*}" "${entry#*@}"
+            done
           done
 
   build-wasm:

--- a/scripts/verify-publish-order.py
+++ b/scripts/verify-publish-order.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-"""Verify crates.io packages are published after workspace dependencies."""
+"""Verify crates.io packages publish in dependency-safe tiers.
+
+The publish workflow groups crates into TIERS: crates within one tier must
+not depend on any published crate in the same tier, and every published
+internal dependency must live in a strictly earlier tier. Tier boundaries are
+the only points where the workflow waits for crates.io indexing.
+"""
 
 import json
 import pathlib
@@ -9,13 +15,18 @@ import subprocess
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 workflow = (ROOT / ".github/workflows/publish.yml").read_text()
-match = re.search(r"CRATES=\(\n(?P<body>.*?)\n\s*\)", workflow, re.DOTALL)
+match = re.search(r"TIERS=\(\n(?P<body>.*?)\n\s*\)", workflow, re.DOTALL)
 if match is None:
-    raise AssertionError("publish workflow CRATES array not found")
+    raise AssertionError("publish workflow TIERS array not found")
 
-published = re.findall(r'^\s*"([^"]+)"\s*$', match.group("body"), re.MULTILINE)
+tier_lines = re.findall(r'^\s*"([^"]+)"\s*$', match.group("body"), re.MULTILINE)
+if not tier_lines:
+    raise AssertionError("publish workflow TIERS array is empty")
+
+tiers = [line.split() for line in tier_lines]
+published = [crate for tier in tiers for crate in tier]
 if len(published) != len(set(published)):
-    raise AssertionError("publish workflow contains duplicate crates")
+    raise AssertionError("publish workflow contains duplicate crates across tiers")
 
 metadata = json.loads(
     subprocess.check_output(
@@ -23,6 +34,10 @@ metadata = json.loads(
     )
 )
 packages = {package["name"]: package for package in metadata["packages"]}
+tier_of = {}
+for index, tier in enumerate(tiers):
+    for name in tier:
+        tier_of[name] = index
 positions = {name: index for index, name in enumerate(published)}
 errors = []
 
@@ -32,15 +47,19 @@ for name in published:
         continue
     for dependency in packages[name]["dependencies"]:
         dependency_name = dependency["name"]
-        if dependency_name not in positions:
+        if dependency_name not in tier_of or dependency_name == name:
             continue
-        if positions[dependency_name] >= positions[name]:
-            errors.append(f"{name}: dependency {dependency_name} must be published first")
+        if tier_of[dependency_name] >= tier_of[name]:
+            errors.append(
+                f"{name} (tier {tier_of[name]}): dependency {dependency_name} "
+                f"must be in a strictly earlier tier (found tier "
+                f"{tier_of[dependency_name]})"
+            )
 
 if positions.get("amari-discovery", -1) >= positions.get("amari", -1):
     errors.append("amari-discovery must be published before amari")
 
 if errors:
-    raise AssertionError("invalid publish order:\n- " + "\n- ".join(errors))
+    raise AssertionError("invalid publish tiers:\n- " + "\n- ".join(errors))
 
-print("publish order is dependency-safe")
+print(f"publish tiers are dependency-safe ({len(tiers)} tiers, {len(published)} crates)")

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-"""Verify that publish validation never executes legacy GPU runtime tests."""
+"""Pin the publish workflow's validation policy (post-0.24.1 velocity redesign).
+
+Policy:
+- The validate job runs on the dedicated self-hosted release runner as a fast
+  smoke gate. The full test/clippy/docs matrix is owned by PR CI
+  (ci.yml + mathematical-correctness.yml), which every tagged commit has
+  already passed; publish-time duplication cost ~55-60 minutes per release.
+- Validate must not contain cargo test or cargo clippy invocations, must not
+  use run_all_tests.sh, and must not serialize tests globally.
+- crates.io publishing must not use fixed indexing sleeps (the 0.24.1 release
+  spent ~20 minutes in sleep 45 calls); it must poll the sparse index at tier
+  boundaries instead.
+- All four publish jobs pin the verified Rust 1.97.1 toolchain through
+  dtolnay/rust-toolchain@1.97.1 plus the single global RUSTUP_TOOLCHAIN
+  override.
+"""
 
 from pathlib import Path
 import re
@@ -14,56 +29,80 @@ if match is None:
     raise AssertionError("publish workflow validate job not found")
 
 validate = match.group("body")
-commands = [
-    line.strip()
-    for line in validate.splitlines()
-    if line.strip().startswith("cargo test ")
-]
-workspace = [line for line in commands if line.startswith("cargo test --workspace")]
-expected_workspace = ["cargo test --workspace --exclude amari-gpu"]
-if workspace != expected_workspace:
-    raise AssertionError(
-        f"expected one GPU-excluded workspace test, found: {workspace!r}"
-    )
 
-for required in (
-    "cargo test -p amari-discovery --all-features",
-    "cargo test -p amari-holographic --all-features",
-):
-    if required not in commands:
-        raise AssertionError(f"missing required publish test: {required}")
+runs_on_lines = [
+    line.strip() for line in validate.splitlines() if line.strip().startswith("runs-on:")
+]
+if runs_on_lines != ["runs-on: [self-hosted, release]"]:
+    raise AssertionError(
+        "validate job must run on the dedicated self-hosted release runner; "
+        f"found: {runs_on_lines!r}"
+    )
 
 timeout_lines = [
     line.strip()
     for line in validate.splitlines()
     if line.strip().startswith("timeout-minutes:")
 ]
-if timeout_lines != ["timeout-minutes: 90"]:
+if timeout_lines != ["timeout-minutes: 30"]:
     raise AssertionError(
-        "validate job must use the empirically bounded 90-minute timeout; "
+        "validate smoke gate must keep the bounded 30-minute timeout; "
         f"found: {timeout_lines!r}"
     )
+
+active_validate = [
+    line.split("#", 1)[0]
+    for line in validate.splitlines()
+    if line.split("#", 1)[0].strip()
+]
+if any("cargo test" in line for line in active_validate):
+    raise AssertionError(
+        "publish-time cargo test reintroduces the duplicated matrix; "
+        "the full test matrix is enforced by PR CI on the tagged commits"
+    )
+if any("cargo clippy" in line for line in active_validate):
+    raise AssertionError(
+        "publish-time cargo clippy reintroduces the duplicated matrix; "
+        "warning-denied clippy is enforced by PR CI on the tagged commits"
+    )
 if "--test-threads" in validate:
-    raise AssertionError("publish tests must not use global serialization")
+    raise AssertionError("publish validation must not use global serialization")
 if "./run_all_tests.sh" in validate:
     raise AssertionError("run_all_tests.sh reintroduces amari-gpu runtime tests")
-clippy_commands = [
-    line.strip()
-    for line in validate.splitlines()
-    if line.strip().startswith("cargo clippy ")
+
+required_smoke_steps = [
+    "cargo fmt --all -- --check",
+    "scripts/version-sync.sh verify",
+    "scripts/verify-release-metadata.py",
+    "generate_catalog",
+    "scripts/generate-discovery-wasm-surface.sh",
+    "scripts/verify-publish-order.py",
+    "scripts/verify-workflow-crates.sh",
+    "scripts/verify-amari-binary-owner.py",
+    "cargo check --workspace --all-features",
 ]
-expected_clippy = [
-    "cargo clippy --workspace --all-features -- -D warnings",
-    (
-        "cargo clippy --workspace --all-targets --all-features -- "
-        "-D warnings -A clippy::needless_range_loop -A clippy::collapsible_match"
-    ),
-]
-if clippy_commands != expected_clippy:
+for required in required_smoke_steps:
+    if required not in validate:
+        raise AssertionError(f"missing required smoke step: {required}")
+
+publish_match = re.search(
+    r"(?ms)^  publish-crates:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n)", workflow
+)
+if publish_match is None:
+    raise AssertionError("publish workflow publish-crates job not found")
+publish = publish_match.group("body")
+
+if "TIERS=(" not in publish:
+    raise AssertionError("publish-crates must publish in dependency tiers (TIERS)")
+if "CRATES=(" in publish:
+    raise AssertionError("stale flat CRATES array found; use tiered TIERS")
+if re.search(r"sleep\s+45", publish):
     raise AssertionError(
-        "expected warning-denied normal targets plus the documented tagged-test "
-        f"lint exception, found: {clippy_commands!r}"
+        "fixed indexing sleeps are forbidden; poll the sparse index instead"
     )
+for required in ("sparse_index_url", "wait_for_index", "index.crates.io"):
+    if required not in publish:
+        raise AssertionError(f"publish-crates must poll the sparse index ({required})")
 
 active_lines = [
     line.split("#", 1)[0].strip()
@@ -97,4 +136,4 @@ if preamble_overrides != [release_override] or all_overrides != [release_overrid
         f"override, RUSTUP_TOOLCHAIN 1.97.1; found: {all_overrides!r}"
     )
 
-print("publish test scope and effective release toolchain are pinned")
+print("publish workflow policy is pinned (self-hosted smoke, tiered polling)")

--- a/scripts/verify-release-metadata.py
+++ b/scripts/verify-release-metadata.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Verify release metadata consistency for the tagged version.
+
+Checks, against cargo metadata:
+- every workspace package version equals the expected release version;
+- every internal dependency requirement is either `*` (workspace
+  inheritance), `=<version>`, or `^<version>` for the expected version.
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+
+if len(sys.argv) != 2:
+    raise SystemExit("usage: verify-release-metadata.py <expected-version>")
+
+expected = sys.argv[1]
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+metadata = json.loads(
+    subprocess.check_output(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"], cwd=ROOT
+    )
+)
+packages = metadata["packages"]
+names = {package["name"] for package in packages}
+errors = []
+
+for package in packages:
+    if package["version"] != expected:
+        errors.append(
+            f"{package['name']}: version {package['version']} != {expected}"
+        )
+
+allowed_reqs = {"*", f"={expected}", f"^{expected}"}
+for package in packages:
+    for dependency in package["dependencies"]:
+        if dependency["name"] not in names:
+            continue
+        req = dependency["req"]
+        if req not in allowed_reqs:
+            errors.append(
+                f"{package['name']}: internal dependency {dependency['name']} "
+                f"has requirement {req!r} (allowed: {sorted(allowed_reqs)})"
+            )
+
+if errors:
+    raise AssertionError("release metadata mismatch:\n- " + "\n- ".join(errors))
+
+print(f"release metadata is consistent at {expected} ({len(packages)} packages)")

--- a/scripts/verify-workflow-crates.sh
+++ b/scripts/verify-workflow-crates.sh
@@ -11,7 +11,7 @@ echo ""
 WORKSPACE_MEMBERS=$(grep -A 1 "^\[workspace\]" Cargo.toml | grep "members" | sed 's/members = \[//' | sed 's/\]//' | tr ',' '\n' | sed 's/"//g' | sed 's/ //g' | grep -v "^$")
 
 # Extract crates from publish.yml TIERS (one quoted space-separated tier per line)
-PUBLISH_CRATES=$(awk '/TIERS=\(/{flag=1; next} flag && /^\s*\)/{flag=0} flag {print}' .github/workflows/publish.yml | grep -oE '"[^"]+"' | tr -d '"' | tr ' ' '\n' | grep -v "^$" | sort -u)
+PUBLISH_CRATES=$(awk '/TIERS=\(/{flag=1; next} flag && /^[[:space:]]*\)/{flag=0} flag {print}' .github/workflows/publish.yml | grep -oE '"[^"]+"' | tr -d '"' | tr ' ' '\n' | grep -v "^$" | sort -u)
 
 # Exclude crates that are intentionally not published to crates.io
 # amari-wasm: Published to npm instead

--- a/scripts/verify-workflow-crates.sh
+++ b/scripts/verify-workflow-crates.sh
@@ -10,15 +10,15 @@ echo ""
 # Extract workspace members from Cargo.toml
 WORKSPACE_MEMBERS=$(grep -A 1 "^\[workspace\]" Cargo.toml | grep "members" | sed 's/members = \[//' | sed 's/\]//' | tr ',' '\n' | sed 's/"//g' | sed 's/ //g' | grep -v "^$")
 
-# Extract crates from publish.yml
-PUBLISH_CRATES=$(awk '/CRATES=\(/{flag=1; next} flag && /^\s*\)/{flag=0} flag {print}' .github/workflows/publish.yml | grep -E '^\s*"amari-' | sed 's/"//g' | sed 's/ //g' | grep -v "^$")
+# Extract crates from publish.yml TIERS (one quoted space-separated tier per line)
+PUBLISH_CRATES=$(awk '/TIERS=\(/{flag=1; next} flag && /^\s*\)/{flag=0} flag {print}' .github/workflows/publish.yml | grep -oE '"[^"]+"' | tr -d '"' | tr ' ' '\n' | grep -v "^$" | sort -u)
 
 # Exclude crates that are intentionally not published to crates.io
 # amari-wasm: Published to npm instead
 EXCLUDED_CRATES="amari-wasm"
 
 # Also check main amari crate
-PUBLISH_CRATES=$(echo "$PUBLISH_CRATES" | grep -v '^"amari"$')
+PUBLISH_CRATES=$(echo "$PUBLISH_CRATES" | grep -v '^amari$')
 WORKSPACE_MEMBERS=$(echo "$WORKSPACE_MEMBERS" | grep -v "^amari$")
 
 # Filter out excluded crates from workspace members for comparison


### PR DESCRIPTION
# Cut the publish pipeline from ~90 min to ~25 min

Post-0.24.1 retrospective: tag-to-published took ~90 minutes (55–60 min validate + 25m21s crates.io publish + 6m41s WASM). This PR implements the three velocity changes agreed after the release.

## 1. `validate` → self-hosted smoke gate on a dedicated release runner

- `runs-on: [self-hosted, release]` — a dedicated runner registered for this repo.
- Scope slimmed to a fast smoke: `fmt --check`, `version-sync.sh verify`, new release-metadata audit, catalog + WASM-surface determinism, publish-order/tier safety, workflow-policy check, binary-ownership check, `cargo check --workspace --all-features`.
- `clean: false` keeps a persistent `target/` between runs. **Warm timing measured: full `cargo check --all-features` = 23.5s; entire smoke validation = ~1–2 minutes** (was 55–60 min).
- The full test/clippy/docs matrix is **not** weakened — it remains enforced by PR CI (`ci.yml` + `mathematical-correctness.yml`) on every commit that reaches a tag. Publish-time re-execution was pure duplication of the PR gate.

### Runner hosting & privacy

The runner runs **containerized (Docker)** with generic runner/machine names (`ia-release-x64-01`), so public job logs disclose no host identifiers (both `Runner name` and `Machine name` in `Set up job` come from the container identity). The container image is a minimal ubuntu:24.04 + build deps (gmp/mpfr/mpc, m4, wasm-pack 0.15.0) with bind-mounted persistent volumes for the agent config, cargo registry, rustup, and `_work` (warm caches survive restarts; `docker rm`-and-`run` is the upgrade path). Dockerfile lives host-side; nothing host-specific appears in this repo.

## 2. `publish-crates` → dependency tiers + sparse-index polling

- 27 crates grouped into **9 tiers** computed from `cargo metadata`; crates in a tier never depend on another crate in the same tier, so indexing only needs observing at tier boundaries.
- Fixed `sleep 45` per crate (**20m15s of the 25m21s** 0.24.1 publish) replaced by polling `index.crates.io` until each tier is visible (10s interval, 300s timeout, typically 10–30s). Skip-if-already-published now also uses the sparse index instead of the rate-limited `cargo search` API.
- **Deviation noted for review:** intra-tier *parallel* publishing was evaluated and deferred — cargo lock contention + crates.io rate-limit burst risk buys only ~2–3 min over sequential-in-tier once sleeps are gone. Can revisit if tier sizes grow.

## 3. Verifiers pin the new policy (no silent weakening)

- `verify-publish-order.py` — parses `TIERS`, requires every internal dep in a strictly earlier tier (cargo metadata checked). Negative test: same-tier dep → caught.
- `verify-publish-test-scope.py` — rewritten: pins `[self-hosted, release]` + 30-min timeout, **forbids** `cargo test`/`cargo clippy` in validate (that's PR CI's job), forbids fixed `sleep 45`, requires sparse-index polling, keeps the four Rust 1.97.1 toolchain pins. Negative tests: smuggled `cargo test` and `cargo clippy` (single-line `run:` form) → both caught.
- `verify-release-metadata.py` (new) — workspace version + internal dependency requirement audit (allows `*`, `=X`, `^X` only). Negative test: wrong version → caught.
- `verify-workflow-crates.sh` — reads `TIERS` instead of `CRATES`.

## Evidence

- All four verifiers pass locally at 0.24.1 (28 packages, 9 tiers / 27 crates dependency-safe).
- Sparse-index helpers tested live against crates.io (`amari-core@0.24.1` found, `9.99.9` absent, prefix rules for 1/2/3-char names).
- Publish-loop bash syntax-checked; YAML parsed.
- **End-to-end on the containerized runner: [run 31049481422](https://github.com/Industrial-Algebra/Amari/actions/runs/31049481422) — full smoke validation PASS in 1m44s**, all 13 steps (dispatch on this branch, both publish inputs false; publish/WASM/npm jobs correctly skipped). Earlier iterations on the same runner image caught and fixed real environment gaps (wasm-pack, gmp/mpfr/mpc, m4) — all now baked into the image.
- One portability fix included: `verify-workflow-crates.sh` used awk `\s` (GNU extension), silently broken under **mawk**; switched to POSIX `[[:space:]]`. ubuntu-latest runners ship gawk, which is why it never fired on GitHub-hosted CI (the old script had the same latent pattern).

## Expected result

Tag-to-published ≈ **20–25 min** (smoke ~2 min + tiered publish ~10 min + WASM ~7 min), down from ~90 min.

## Not in this PR

- **npm auth fix** (granular token transition) — deliberately separate: PR #237. npm stays manual-by-Justin until that lands.
