### PR TITLE
fix: correct npm package repository URL for OIDC provenance

### DIFF
--- a/amari-wasm/examples/package.json
+++ b/amari-wasm/examples/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/justinelliottcobb/Amari.git",
+    "url": "https://github.com/Industrial-Algebra/Amari",
     "directory": "amari-wasm/examples"
   }
 }

--- a/amari-wasm/package.json
+++ b/amari-wasm/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/justinelliottcobb/Amari.git"
+    "url": "https://github.com/Industrial-Algebra/Amari"
   },
   "license": "MIT OR Apache-2.0",
   "keywords": [


### PR DESCRIPTION
# Fix npm package repository URL for OIDC provenance

## Why

The npm 0.24.1 OIDC publish ([run 31136769878](https://github.com/Industrial-Algebra/Amari/actions/runs/31136769878)) reached the registry with a **signed provenance bundle** (sigstore `logIndex=2363115755`) — trusted publishing itself works — but npm rejected the publish:

```
E422 Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is
"git+https://github.com/justinelliottcobb/Amari.git", expected to match
"https://github.com/Industrial-Algebra/Amari" from provenance
```

npm requires `package.json`'s repository to match the OIDC token's repo claim exactly. The stale URL predates the repo transfer to the Industrial-Algebra org.

## What

- `amari-wasm/package.json` — `repository.url` → `https://github.com/Industrial-Algebra/Amari` (**this is the fix**: the wasm-pack build copies this field into the published artifact; `pkg*/` are gitignored build outputs).
- `amari-wasm/examples/package.json` — same stale URL, hygiene only (not published).

## Verification

- No version bump, no code change; CI matrix runs as usual.
- After merge: re-dispatch `publish.yml` (version=0.24.1, crates=false, npm=true) — the previously approved publication — which should now pass the provenance check.
