### PR TITLE
fix: correct amari-wasm Cargo.toml repository for npm provenance

### DIFF
--- a/amari-wasm/Cargo.toml
+++ b/amari-wasm/Cargo.toml
@@ -5,8 +5,8 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "WebAssembly bindings for Amari mathematical computing library - geometric algebra, tropical algebra, automatic differentiation, measure theory, fusion systems, and information geometry"
-repository = "https://github.com/justinelliottcobb/Amari"
-homepage = "https://github.com/justinelliottcobb/Amari"
+repository = "https://github.com/Industrial-Algebra/Amari"
+homepage = "https://github.com/Industrial-Algebra/Amari"
 keywords = ["wasm", "webassembly", "geometric-algebra", "tropical-algebra", "autodiff"]
 categories = ["mathematics", "science", "wasm", "web-programming"]
 


### PR DESCRIPTION
# Fix amari-wasm Cargo.toml repository (npm provenance, attempt 2 follow-up)

## Why

PR #238 fixed `amari-wasm/package.json`, but the re-dispatch ([run 31138695124](https://github.com/Industrial-Algebra/Amari/actions/runs/31138695124)) failed with the **same** E422 stale-URL rejection. Cause: wasm-pack generates the published `pkg/package.json` from **Cargo.toml** metadata — the package.json fix never reached the artifact. `amari-wasm/Cargo.toml` had its own stale literal:

```
repository = "https://github.com/justinelliottcobb/Amari"
homepage  = "https://github.com/justinelliottcobb/Amari"
```

## What

`amari-wasm/Cargo.toml` `repository` + `homepage` → `https://github.com/Industrial-Algebra/Amari`.

Positive signal from the failed run: OIDC + provenance signing worked again (sigstore `logIndex=2363499400`); only the repository exact-match check fails.

## Out of scope (separate cleanup)

Workspace-root `Cargo.toml` and other member crates carry the same pre-transfer URL. That only affects crates.io metadata display, where the redirect works — propose a dedicated chore PR to normalize all repository/homepage URLs.

## Verification

Metadata-only change; CI runs as usual. After merge: re-dispatch the approved npm 0.24.1 publication.
