### PR TITLE
docs: record npm 0.24.1 OIDC publication in v0.24.1 evidence

### DIFF
--- a/docs/releases/v0.24.1-publication-evidence.md
+++ b/docs/releases/v0.24.1-publication-evidence.md
@@ -38,3 +38,27 @@ Date: 2026-08-04. Tag: `v0.24.1` (annotated) on `b4fd692` (master, merge commit 
 ## Pre-merge verification matrix (at release head `f2372e2`)
 
 Recorded in full in the PR #234 body: fmt, `git diff --check`, version-sync verify, cargo metadata audit, workflow/crate/publish-order/test-scope/sharding verifiers, catalog + WASM surface determinism (hash `97684d902767a412e740b2e83d30ebec40e56dec61a35008766bf922f06ed5db`), discovery all-features + no-default-features tests, workspace tests excluding `amari-gpu`, scoped and publish-workflow clippy, rustdoc `-D warnings`, `cargo package` + `cargo publish --dry-run` for `amari-core` and `amari-discovery-macros` on Rust 1.97.1.
+
+## npm completion — 2026-08-07 (OIDC trusted publishing)
+
+- Run: https://github.com/Industrial-Algebra/Amari/actions/runs/31337580528
+  on `develop` @ `f3e5722` (inputs: version=0.24.1, publish_crates=false,
+  publish_npm=true). Validate smoke (self-hosted) PASS, Build WASM PASS,
+  Publish to npm PASS, crates.io correctly skipped.
+- Auth: **npm trusted publishing (OIDC)** — no long-lived token; provenance
+  statement auto-generated and published (sigstore `logIndex=2400187910`,
+  SLSA v1 attestation visible at the registry).
+- Registry: `@justinelliottcobb/amari-wasm@0.24.1` live on npmjs.com.
+- Install smoke (clean dir, Node 24): package initializes; dual-number
+  autodiff verified ((2+ε)² = 4+4ε).
+- En-route fixes: npm provenance exact-matches `repository.url` against the
+  OIDC repo claim — corrected the stale pre-transfer URL in
+  `amari-wasm/package.json` (#238) and the authoritative
+  `amari-wasm/Cargo.toml` (#239; wasm-pack generates the published
+  package.json from Cargo.toml metadata).
+- Two earlier attempts (31136769878, 31138695124) failed safe at the
+  registry with E422 (nothing published); the first verified trusted-
+  publisher config was correct (provenance signed, sigstore
+  `logIndex=2363115755`).
+- **v0.24.1 is now complete on all registries**: 27/27 crates.io crates +
+  npm WASM package, with provenance.


### PR DESCRIPTION
Appends the npm completion section to the v0.24.1 publication evidence: run 31337580528 (all jobs green), OIDC trusted publishing with SLSA provenance (sigstore logIndex=2400187910), registry verification, install smoke test, and the #238/#239 repository-URL fixes that unblocked provenance validation. Marks v0.24.1 complete on all registries.