### PR TITLE
build: add rewrite research dependencies (0.25 Cohort 1, Tasks 1–2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,59 @@ jobs:
           fi
           echo "==> WASM surface catalog is up to date"
 
+  msrv:
+    name: MSRV Check (1.89)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.89.0
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.89.0
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      # Compile-only floor: nalgebra 0.35 / safe_arch 1.1 / wide 1.6.1 require
+      # rustc 1.89, so the workspace rust-version is 1.89 (raised from the
+      # unenforced 1.75 declaration in the 0.25 rewrite baseline).
+      - name: Check workspace at MSRV
+        run: cargo check --workspace
+
+  test-z3-vendored:
+    name: Rewrite SMT (Vendored Z3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-z3-${{ hashFiles('**/Cargo.lock') }}
+
+      # Vendored Z3 compiles the solver from source via CMake into target/;
+      # cache the full build output keyed by compiler and lockfile so only
+      # lockfile changes rebuild Z3 (cold build ~4-5 min on hosted runners).
+      - name: Cache vendored Z3 build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-z3-vendored-${{ hashFiles('**/Cargo.lock') }}-v1
+
+      - name: Test rewrite smt feature
+        run: cargo test -p amari-rewrite --features smt
+
   benchmark:
     name: Performance Benchmarks
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ wasm-pack.log
 # Allow checked-in .d.ts test fixtures (overrides *.d.ts above)
 !amari-discovery/tests/fixtures/wasm-surface/*.d.ts
 
+.z3-trace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ version = "0.24.1"
 authors = ["Amari Contributors"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.89"
 
 [workspace.dependencies]
 # Amari crates (internal dependencies)
@@ -133,7 +133,7 @@ serde_json = "1"
 schemars = "1"
 toml = "0.8"
 walkdir = "2"
-sha2 = "0.10"
+sha2 = { version = "0.10", default-features = false }
 hex = "0.4"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A unified mathematical computing library featuring geometric algebra, differential calculus, measure theory, probability theory on geometric spaces, functional analysis (Hilbert spaces, operators, spectral theory), algebraic topology (homology, persistent homology, Morse theory), dynamical systems analysis (ODE solvers, stability, bifurcations, chaos, Lyapunov exponents), relativistic physics, tropical algebra, automatic differentiation, holographic associative memory (Vector Symbolic Architectures), optical field operations for holographic displays, term rewriting (ARS/TRS), and information geometry. The library provides multi-GPU infrastructure with intelligent workload distribution and complete WebAssembly support for browser deployment. The 0.24.0 cycle adds the agent-first `amari-discovery` runtime and canonical additive holographic `superpose`/`scale` operations while preserving the 0.23 exact rational, surcomplex, arbitrary-signature WASM, and rewrite foundations.
 
-[![Rust](https://img.shields.io/badge/Rust-1.75+-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/Rust-1.89+-orange.svg)](https://www.rust-lang.org/)
 [![WebAssembly](https://img.shields.io/badge/WebAssembly-Ready-blue.svg)](https://webassembly.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-green.svg)](LICENSE)
@@ -983,7 +983,7 @@ The `holographic` feature includes GPU-accelerated optical field operations:
 
 ### Prerequisites
 
-- Rust 1.75+ with `cargo`
+- Rust 1.89+ with `cargo`
 - Node.js 16+ (for TypeScript bindings)
 - `wasm-pack` (for WASM builds)
 

--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "version": "0.24.1",
-  "description": "Generated structural catalog for Amari 0.24.1: 27 crates, 104 dependency edges",
-  "content_hash": "97684d902767a412e740b2e83d30ebec40e56dec61a35008766bf922f06ed5db",
+  "description": "Generated structural catalog for Amari 0.24.1: 27 crates, 105 dependency edges",
+  "content_hash": "3ddfd8f3f9616cc28ef085916868813533b003c13347bfb8cb272a95db5f5a58",
   "crates": [
     {
       "name": "amari",
@@ -373728,17 +373728,30 @@
           ]
         },
         {
+          "name": "holographic-guidance",
+          "enables": [
+            "dep:amari-holographic",
+            "std"
+          ]
+        },
+        {
           "name": "macros"
         },
         {
           "name": "network",
           "enables": [
             "dep:amari-network",
-            "neural"
+            "neural",
+            "std"
           ]
         },
         {
-          "name": "neural"
+          "name": "neural",
+          "enables": [
+            "dep:candle-core",
+            "dep:candle-nn",
+            "std"
+          ]
         },
         {
           "name": "serialize",
@@ -373747,7 +373760,11 @@
           ]
         },
         {
-          "name": "smt"
+          "name": "smt",
+          "enables": [
+            "dep:z3",
+            "std"
+          ]
         },
         {
           "name": "std"
@@ -373755,11 +373772,36 @@
       ],
       "dependencies": [
         {
+          "alias": "amari-holographic",
+          "package": "amari-holographic",
+          "kind": "normal",
+          "version": "0.24.1",
+          "path": "amari-holographic",
+          "optional": true,
+          "default_features": true
+        },
+        {
           "alias": "amari-network",
           "package": "amari-network",
           "kind": "normal",
           "version": "0.24.1",
           "path": "amari-network",
+          "optional": true,
+          "default_features": true
+        },
+        {
+          "alias": "candle-core",
+          "package": "candle-core",
+          "kind": "normal",
+          "version": "=0.11.0",
+          "optional": true,
+          "default_features": true
+        },
+        {
+          "alias": "candle-nn",
+          "package": "candle-nn",
+          "kind": "normal",
+          "version": "=0.11.0",
           "optional": true,
           "default_features": true
         },
@@ -373775,12 +373817,31 @@
           ]
         },
         {
+          "alias": "sha2",
+          "package": "sha2",
+          "kind": "normal",
+          "version": "0.10",
+          "optional": false,
+          "default_features": false
+        },
+        {
           "alias": "thiserror",
           "package": "thiserror",
           "kind": "normal",
           "version": "2.0",
           "optional": false,
           "default_features": true
+        },
+        {
+          "alias": "z3",
+          "package": "z3",
+          "kind": "normal",
+          "version": "=0.20.2",
+          "optional": true,
+          "default_features": false,
+          "features": [
+            "vendored"
+          ]
         }
       ],
       "targets": [
@@ -465273,6 +465334,10 @@
     {
       "from": "amari-relativistic",
       "to": "amari-core"
+    },
+    {
+      "from": "amari-rewrite",
+      "to": "amari-holographic"
     },
     {
       "from": "amari-rewrite",

--- a/amari-discovery/src/catalog/generator/wasm.rs
+++ b/amari-discovery/src/catalog/generator/wasm.rs
@@ -1369,7 +1369,7 @@ impl WasmSurfaceParser {
             && (remaining[keyword.len()..]
                 .chars()
                 .next()
-                .map_or(true, |c| !c.is_ascii_alphanumeric() && c != '_'))
+                .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_'))
     }
 
     fn read_method_from_name(&mut self, _name: &str, _is_static: bool) -> Option<String> {

--- a/amari-discovery/src/inspect/rust/inspect.rs
+++ b/amari-discovery/src/inspect/rust/inspect.rs
@@ -140,7 +140,7 @@ fn classify_file(rel_path: &str, pkg_dir: &str, package_name: &str) -> RustFileK
     let p = Path::new(&pkg_rel);
 
     if p.file_name().is_some_and(|n| n == "build.rs")
-        && p.parent().map_or(true, |par| par.as_os_str().is_empty())
+        && p.parent().is_none_or(|par| par.as_os_str().is_empty())
     {
         return RustFileKind::BuildScript {
             package: package_name.to_string(),

--- a/amari-dynamics/src/lyapunov/spectrum.rs
+++ b/amari-dynamics/src/lyapunov/spectrum.rs
@@ -218,7 +218,7 @@ impl LyapunovSpectrum {
     /// Check if exponents come in ± pairs (symplectic structure)
     pub fn is_symplectic(&self, tolerance: f64) -> bool {
         let n = self.exponents.len();
-        if n % 2 != 0 {
+        if !n.is_multiple_of(2) {
             return false;
         }
 

--- a/amari-measure/src/numerical_integration.rs
+++ b/amari-measure/src/numerical_integration.rs
@@ -143,7 +143,7 @@ where
         )));
     }
 
-    if num_intervals == 0 || num_intervals % 2 != 0 {
+    if num_intervals == 0 || !num_intervals.is_multiple_of(2) {
         return Err(MeasureError::computation(
             "Number of intervals must be positive and even".to_string(),
         ));

--- a/amari-probabilistic/src/sampling/mcmc.rs
+++ b/amari-probabilistic/src/sampling/mcmc.rs
@@ -76,7 +76,7 @@ pub struct MCMCDiagnostics {
 impl MCMCDiagnostics {
     /// Check if the sampler has converged (R-hat < 1.1)
     pub fn is_converged(&self) -> bool {
-        self.r_hat.map_or(true, |r| r < 1.1)
+        self.r_hat.is_none_or(|r| r < 1.1)
     }
 }
 

--- a/amari-rewrite/Cargo.toml
+++ b/amari-rewrite/Cargo.toml
@@ -14,13 +14,19 @@ categories = ["mathematics", "science", "algorithms"]
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }
+sha2 = { workspace = true }
 amari-network = { workspace = true, optional = true }
+amari-holographic = { workspace = true, optional = true }
+candle-core = { version = "=0.11.0", optional = true }
+candle-nn = { version = "=0.11.0", optional = true }
+z3 = { version = "=0.20.2", default-features = false, features = ["vendored"], optional = true }
 
 [features]
 default = ["std"]
 std = []
 serialize = ["dep:serde"]
 macros = []
-smt = []
-neural = []
-network = ["dep:amari-network", "neural"]
+smt = ["std", "dep:z3"]
+neural = ["std", "dep:candle-core", "dep:candle-nn"]
+network = ["std", "neural", "dep:amari-network"]
+holographic-guidance = ["std", "dep:amari-holographic"]

--- a/amari-rewrite/src/synthesis/inference.rs
+++ b/amari-rewrite/src/synthesis/inference.rs
@@ -1,6 +1,6 @@
 //! Rule inference from example rewrite steps.
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, string::ToString, vec, vec::Vec};
 
 use crate::{
     trs::{Rule, Term, Variable},

--- a/amari-rewrite/tests/research_dependencies.rs
+++ b/amari-rewrite/tests/research_dependencies.rs
@@ -1,0 +1,76 @@
+//! Research dependency baseline proof for the 0.25 inverse-rewrite expansion.
+//!
+//! Pins the exact external surface each research feature is allowed to use:
+//! `sha2` as a small no_std core dependency for canonical evidence digests,
+//! Candle CPU tensors under `neural`, vendored Z3 under `smt`, and the
+//! optional holographic/network guidance crates under their features.
+
+use sha2::{Digest, Sha256};
+
+/// `sha2` is a core (always-on) dependency used for canonical relation,
+/// language, replay, and research-backend evidence identity. This vector is
+/// the well-known SHA-256 of the empty string.
+#[test]
+fn sha256_core_dependency_matches_known_vector() {
+    let digest = Sha256::digest(b"");
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    assert_eq!(
+        hex,
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+/// `neural` wires Candle CPU-only: a tensor computation plus a VarMap/
+/// backprop round trip proves both `candle-core` and `candle-nn` resolve.
+#[cfg(feature = "neural")]
+#[test]
+fn neural_feature_provides_candle_cpu_tensor_and_varmap() {
+    use candle_core::{DType, Device, Tensor};
+    use candle_nn::{linear, Linear, Module, VarBuilder, VarMap};
+
+    let device = Device::Cpu;
+    let a = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], (2, 2), &device).unwrap();
+    let b = Tensor::eye(2, DType::F32, &device).unwrap();
+    let product = a.matmul(&b).unwrap();
+    let flat: Vec<f32> = product.flatten_all().unwrap().to_vec1().unwrap();
+    assert_eq!(flat, vec![1.0, 2.0, 3.0, 4.0]);
+
+    let var_map = VarMap::new();
+    let vb = VarBuilder::from_varmap(&var_map, DType::F32, &device);
+    let layer: Linear = linear(2, 1, vb).unwrap();
+    let output = layer.forward(&a).unwrap();
+    assert_eq!(output.dims(), &[2, 1]);
+}
+
+/// `smt` wires vendored Z3: a trivial satisfiability check proves the
+/// vendored solver builds and runs without a system Z3 installation.
+#[cfg(feature = "smt")]
+#[test]
+fn smt_feature_provides_vendored_z3_solver() {
+    use z3::{ast::Int, SatResult, Solver};
+
+    let solver = Solver::new();
+    let x = Int::new_const("x");
+    let three = Int::from_i64(3);
+    solver.assert(x.gt(&three));
+    assert_eq!(solver.check(), SatResult::Sat);
+}
+
+/// `network` guidance keeps its existing optional `amari-network` surface.
+#[cfg(feature = "network")]
+#[test]
+fn network_feature_provides_geometric_network_types() {
+    let network = amari_network::GeometricNetwork::<3, 0, 0>::new();
+    assert_eq!(network.num_nodes(), 0);
+}
+
+/// `holographic-guidance` adds the optional `amari-holographic` dependency
+/// used by deterministic trace recall guidance.
+#[cfg(feature = "holographic-guidance")]
+#[test]
+fn holographic_guidance_feature_provides_holographic_types() {
+    use amari_holographic::BindingAlgebra;
+
+    let element = amari_holographic::FHRRAlgebra::<8>::identity();
+    assert_eq!(element.dimension(), 8);
+}

--- a/amari-topology/src/persistence.rs
+++ b/amari-topology/src/persistence.rs
@@ -161,7 +161,7 @@ impl BarcodeInterval {
 
     /// Check if the feature is still alive at the given time.
     pub fn is_alive_at(&self, time: f64) -> bool {
-        time >= self.birth && self.death.map_or(true, |d| time < d)
+        time >= self.birth && self.death.is_none_or(|d| time < d)
     }
 
     /// Check if this is an essential feature (never dies).


### PR DESCRIPTION
# 0.25 Cohort 1 (Tasks 1–2): baseline + research dependency baseline

First slice of the approved [0.25 comprehensive rewrite & inverse expansion plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md). Base: `7c7f261` (post-#240 develop tip, v0.24.1 fully shipped incl. npm OIDC).

## Task 1 — baseline verification checkpoint

All release facts verified (v0.24.1 tag on `b4fd692`, backmerge `ce8f6d2`, 27/27 crates.io, npm with SLSA provenance). No factual status docs required correction → verification-only, no commit.

## Task 2 — research dependency baseline

**`amari-rewrite` manifest (wired exactly per the design table):**
- `sha2` (workspace, `default-features = false`) — **core** dep for canonical evidence digests
- `neural = ["std", "dep:candle-core", "dep:candle-nn"]` — pinned `=0.11.0`, CPU-only
- `smt = ["std", "dep:z3"]` — pinned `=0.20.2`, vendored, no-default
- `network = ["std", "neural", "dep:amari-network"]`
- `holographic-guidance = ["std", "dep:amari-holographic"]` — new
- default/no-default trees verified to carry **zero** heavy deps

**⚠️ MSRV deviation (recorded with evidence, as the plan requires):** plan said 1.85; reality on develop is that `nalgebra 0.35.0` / `safe_arch 1.1.0` / `wide 1.6.1` (via amari-network, amari-relativistic) **require rustc 1.89**, and the old `rust-version = "1.75"` was unenforced (no MSRV CI job existed). Set `rust-version = "1.89"` and added the `MSRV Check (1.89)` job rather than forcing dependency downgrades. Publish toolchain 1.97.1 unaffected.

**CI:** `MSRV Check (1.89)` + `Rewrite SMT (Vendored Z3)` (45-min cap, target/ cache keyed on lockfile). Existing jobs and WASM isolation untouched.

**Drive-by fix:** pre-existing `--no-default-features` breakage in `synthesis/inference.rs` (missing `alloc::vec`/`ToString` imports — 3 errors on develop). Decision 2 requires no_std+alloc capability, so this fixes GREEN rather than gating around it.

**Also:** structural catalog regenerated for the new dependency edges (105 edges, hash `3ddfd8f3…`); `.z3-trace` vendored-build artifact gitignored. Note: `Cargo.lock` is gitignored in this repo (unchanged behavior; CI cache keys hash it at resolve time as before).

## Evidence

- Preflight: `candle-core/candle-nn 0.11.0`, `z3 0.20.2` exact pins live on crates.io ✓
- RED: `research_dependencies.rs` failed before deps (`E0432 unresolved import sha2`) ✓
- GREEN: SHA-256 known-vector; Candle CPU matmul + VarMap linear; vendored Z3 sat-check (**cold 228s / warm 0.84s**); FHRR identity dimension; GeometricNetwork types ✓
- `cargo +1.89.0 check --workspace` PASS; `cargo test -p amari-rewrite --all-features` — 13/13 suites PASS
- sha2 consumers (discovery `catalog_integrity` 11 tests, `wire_schema_registry` 9 tests) PASS under no-default sha2
- `version-sync verify 0.24.1` PASS; publish tiers dependency-safe (9 tiers, holographic t1 < rewrite t4 ✓); discovery sharding verifier PASS; WASM surface unchanged; fmt clean

## Not in this PR

Task 3 (`amari-rewrite-macros` scaffold) onward — next cohort commits. The `macros = []` placeholder remains until then.
