### PR TITLE
feat: scaffold rewrite macro crate (0.25 Cohort 1, Task 3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,7 @@ jobs:
           # IMPORTANT: add new crates to the earliest tier after all of their
           # published internal dependencies; keep amari last (aggregate).
           TIERS=(
-            "amari-core amari-cgt amari-flynn-macros amari-discovery-macros"
+            "amari-core amari-cgt amari-flynn-macros amari-discovery-macros amari-rewrite-macros"
             "amari-tropical amari-dual amari-info-geom amari-relativistic amari-holographic amari-surreal amari-enumerative amari-flynn"
             "amari-network amari-fusion amari-automata amari-surcomplex amari-measure"
             "amari-calculus amari-probabilistic amari-rewrite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ path = "examples/networked_physics.rs"
 required-features = ["deterministic"]
 
 [workspace]
-members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal", "amari-surcomplex", "amari-rewrite", "amari-discovery", "amari-discovery-macros"]
+members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal", "amari-surcomplex", "amari-rewrite", "amari-discovery", "amari-discovery-macros", "amari-rewrite-macros"]
 resolver = "2"
 
 [workspace.package]
@@ -112,6 +112,7 @@ amari-surreal = { path = "amari-surreal", version = "0.24.1" }
 amari-surcomplex = { path = "amari-surcomplex", version = "0.24.1" }
 amari-rewrite = { path = "amari-rewrite", version = "0.24.1" }
 amari-discovery-macros = { path = "amari-discovery-macros", version = "0.24.1" }
+amari-rewrite-macros = { path = "amari-rewrite-macros", version = "0.24.1" }
 amari-wasm = { path = "amari-wasm", version = "0.24.1" }
 
 # External dependencies
@@ -128,6 +129,7 @@ rand_distr = "0.6"
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+proc-macro-crate = "3"
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 schemars = "1"

--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "version": "0.24.1",
-  "description": "Generated structural catalog for Amari 0.24.1: 27 crates, 105 dependency edges",
-  "content_hash": "3ddfd8f3f9616cc28ef085916868813533b003c13347bfb8cb272a95db5f5a58",
+  "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 106 dependency edges",
+  "content_hash": "334b1b19cde09b1b2a7544f819de3385ead52a98e53800ae3c01807b325b2de0",
   "crates": [
     {
       "name": "amari",
@@ -373735,7 +373735,10 @@
           ]
         },
         {
-          "name": "macros"
+          "name": "macros",
+          "enables": [
+            "dep:amari-rewrite-macros"
+          ]
         },
         {
           "name": "network",
@@ -373786,6 +373789,15 @@
           "kind": "normal",
           "version": "0.24.1",
           "path": "amari-network",
+          "optional": true,
+          "default_features": true
+        },
+        {
+          "alias": "amari-rewrite-macros",
+          "package": "amari-rewrite-macros",
+          "kind": "normal",
+          "version": "0.24.1",
+          "path": "amari-rewrite-macros",
           "optional": true,
           "default_features": true
         },
@@ -375252,158 +375264,6 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::rewritable",
               "declaration_ident": "Path::root"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable",
-          "kind": "trait",
-          "signature": "pub trait Rewritable : Clone + PartialEq + Debug",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "trait",
-              "signature": "pub trait Rewritable : Clone + PartialEq + Debug",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::child",
-          "kind": "method",
-          "signature": "fn child (& self , index : usize) -> Option < & Self >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn child (& self , index : usize) -> Option < & Self >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::child"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::child_count",
-          "kind": "method",
-          "signature": "fn child_count (& self) -> usize",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn child_count (& self) -> usize",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::child_count"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::positions",
-          "kind": "method",
-          "signature": "fn positions (& self) -> Vec < Path >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn positions (& self) -> Vec < Path >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::positions"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_at",
-          "kind": "method",
-          "signature": "fn replace_at (& self , path : & Path , replacement : Self) -> RewriteResult < Self >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn replace_at (& self , path : & Path , replacement : Self) -> RewriteResult < Self >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::replace_at"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_at_slice",
-          "kind": "method",
-          "signature": "fn replace_at_slice (& self , path : & [usize] , replacement : Self) -> RewriteResult < Self >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn replace_at_slice (& self , path : & [usize] , replacement : Self) -> RewriteResult < Self >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::replace_at_slice"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_child",
-          "kind": "method",
-          "signature": "fn replace_child (& self , index : usize , replacement : Self) -> RewriteResult < Self >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn replace_child (& self , index : usize , replacement : Self) -> RewriteResult < Self >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::replace_child"
-            }
-          ]
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::subterm",
-          "kind": "method",
-          "signature": "fn subterm (& self , path : & Path) -> Option < & Self >",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "is_reexport": true,
-          "source_module": "amari_rewrite::rewritable",
-          "variants": [
-            {
-              "kind": "method",
-              "signature": "fn subterm (& self , path : & Path) -> Option < & Self >",
-              "source_path": "amari-rewrite/src/rewritable.rs",
-              "source_module": "amari_rewrite::rewritable",
-              "is_reexport": true,
-              "declaration_module": "amari_rewrite::rewritable",
-              "declaration_ident": "Rewritable::subterm"
             }
           ]
         },
@@ -378255,82 +378115,6 @@
           ]
         },
         {
-          "export_path": "amari_rewrite::prelude::Rewritable",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 4,
-          "trait_endpoint": {
-            "kind": "local",
-            "module": "amari_rewrite::rewritable",
-            "ident": "Rewritable"
-          },
-          "supertraits": [
-            {
-              "endpoint": {
-                "kind": "external",
-                "path": "Clone"
-              }
-            },
-            {
-              "endpoint": {
-                "kind": "external",
-                "path": "PartialEq"
-              }
-            },
-            {
-              "endpoint": {
-                "kind": "external",
-                "path": "Debug"
-              }
-            }
-          ],
-          "required_items": [
-            {
-              "name": "child_count",
-              "kind": "method",
-              "signature": "fn child_count (& self) -> usize",
-              "status": "required"
-            },
-            {
-              "name": "child",
-              "kind": "method",
-              "signature": "fn child (& self , index : usize) -> Option < & Self >",
-              "status": "required"
-            },
-            {
-              "name": "replace_child",
-              "kind": "method",
-              "signature": "fn replace_child (& self , index : usize , replacement : Self) -> RewriteResult < Self >",
-              "status": "required"
-            }
-          ],
-          "provided_items": [
-            {
-              "name": "subterm",
-              "kind": "method",
-              "signature": "fn subterm (& self , path : & Path) -> Option < & Self >",
-              "status": "provided"
-            },
-            {
-              "name": "replace_at",
-              "kind": "method",
-              "signature": "fn replace_at (& self , path : & Path , replacement : Self) -> RewriteResult < Self >",
-              "status": "provided"
-            },
-            {
-              "name": "positions",
-              "kind": "method",
-              "signature": "fn positions (& self) -> Vec < Path >",
-              "status": "provided"
-            },
-            {
-              "name": "replace_at_slice",
-              "kind": "method",
-              "signature": "fn replace_at_slice (& self , path : & [usize] , replacement : Self) -> RewriteResult < Self >",
-              "status": "provided"
-            }
-          ]
-        },
-        {
           "export_path": "amari_rewrite::rewritable::Rewritable",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 4,
@@ -380902,44 +380686,6 @@
           "is_derived": false
         },
         {
-          "trait_path": "amari_rewrite::prelude::Rewritable",
-          "impl_type_path": "amari_rewrite::prelude::Term",
-          "source_path": "amari-rewrite/src/trs/term.rs",
-          "source_ordinal": 12,
-          "trait_endpoint": {
-            "kind": "local",
-            "module": "amari_rewrite::rewritable",
-            "ident": "Rewritable"
-          },
-          "impl_type_endpoint": {
-            "kind": "local",
-            "module": "amari_rewrite::trs::term",
-            "ident": "Term"
-          },
-          "unsafe_trait": false,
-          "negative": false,
-          "is_derived": false
-        },
-        {
-          "trait_path": "amari_rewrite::prelude::Rewritable",
-          "impl_type_path": "amari_rewrite::trs::Term",
-          "source_path": "amari-rewrite/src/trs/term.rs",
-          "source_ordinal": 12,
-          "trait_endpoint": {
-            "kind": "local",
-            "module": "amari_rewrite::rewritable",
-            "ident": "Rewritable"
-          },
-          "impl_type_endpoint": {
-            "kind": "local",
-            "module": "amari_rewrite::trs::term",
-            "ident": "Term"
-          },
-          "unsafe_trait": false,
-          "negative": false,
-          "is_derived": false
-        },
-        {
           "trait_path": "amari_rewrite::rewritable::Rewritable",
           "impl_type_path": "amari_rewrite::prelude::Term",
           "source_path": "amari-rewrite/src/trs/term.rs",
@@ -381059,64 +380805,64 @@
           "path": "amari_rewrite::Rewritable",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 4,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "top_level"
         },
         {
           "path": "amari_rewrite::Rewritable::child",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 1,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::child_count",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::positions",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 5,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::replace_at",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 4,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::replace_at_slice",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 6,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::replace_child",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 2,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::Rewritable::subterm",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 3,
-          "gate": "always",
-          "status": "enabled",
+          "gate": "feature(\"macros\")",
+          "status": "disabled",
           "surface_kind": "trait_method"
         },
         {
@@ -381494,70 +381240,6 @@
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 4,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "top_level"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::child",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 1,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::child_count",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 0,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::positions",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 5,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_at",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 4,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_at_slice",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 6,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::replace_child",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 2,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
-        },
-        {
-          "path": "amari_rewrite::prelude::Rewritable::subterm",
-          "source_path": "amari-rewrite/src/rewritable.rs",
-          "source_ordinal": 3,
-          "gate": "always",
-          "status": "enabled",
-          "surface_kind": "trait_method"
         },
         {
           "path": "amari_rewrite::prelude::RewriteError",
@@ -382633,6 +382315,222 @@
         "amari_rewrite::trs"
       ],
       "readme": "amari-rewrite/README.md"
+    },
+    {
+      "name": "amari-rewrite-macros",
+      "version": "0.24.1",
+      "description": "Checked procedural macros for amari-rewrite: derive(Rewritable), term!/rule!/relation! constructors",
+      "license": "MIT OR Apache-2.0",
+      "edition": "2021",
+      "manifest_path": "amari-rewrite-macros/Cargo.toml",
+      "library_outputs": [
+        "proc-macro"
+      ],
+      "features": [],
+      "dependencies": [
+        {
+          "alias": "proc-macro-crate",
+          "package": "proc-macro-crate",
+          "kind": "normal",
+          "version": "3",
+          "optional": false,
+          "default_features": true
+        },
+        {
+          "alias": "proc-macro2",
+          "package": "proc-macro2",
+          "kind": "normal",
+          "version": "1.0",
+          "optional": false,
+          "default_features": true
+        },
+        {
+          "alias": "quote",
+          "package": "quote",
+          "kind": "normal",
+          "version": "1.0",
+          "optional": false,
+          "default_features": true
+        },
+        {
+          "alias": "syn",
+          "package": "syn",
+          "kind": "normal",
+          "version": "2.0",
+          "optional": false,
+          "default_features": true,
+          "features": [
+            "full"
+          ]
+        },
+        {
+          "alias": "trybuild",
+          "package": "trybuild",
+          "kind": "development",
+          "version": "1",
+          "optional": false,
+          "default_features": true
+        }
+      ],
+      "targets": [
+        {
+          "name": "amari_rewrite_macros",
+          "kind": "library",
+          "path": "amari-rewrite-macros/src/lib.rs",
+          "crate_types": [
+            "proc-macro"
+          ]
+        }
+      ],
+      "items": [
+        {
+          "path": "amari_rewrite_macros::derive_rewritable",
+          "kind": "fn",
+          "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite_macros",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+              "source_path": "amari-rewrite-macros/src/lib.rs",
+              "source_module": "amari_rewrite_macros",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite_macros",
+              "declaration_ident": "derive_rewritable"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite_macros::relation",
+          "kind": "fn",
+          "signature": "pub fn relation (_input : TokenStream) -> TokenStream",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite_macros",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn relation (_input : TokenStream) -> TokenStream",
+              "source_path": "amari-rewrite-macros/src/lib.rs",
+              "source_module": "amari_rewrite_macros",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite_macros",
+              "declaration_ident": "relation"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite_macros::rule",
+          "kind": "fn",
+          "signature": "pub fn rule (_input : TokenStream) -> TokenStream",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite_macros",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn rule (_input : TokenStream) -> TokenStream",
+              "source_path": "amari-rewrite-macros/src/lib.rs",
+              "source_module": "amari_rewrite_macros",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite_macros",
+              "declaration_ident": "rule"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite_macros::term",
+          "kind": "fn",
+          "signature": "pub fn term (_input : TokenStream) -> TokenStream",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite_macros",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn term (_input : TokenStream) -> TokenStream",
+              "source_path": "amari-rewrite-macros/src/lib.rs",
+              "source_module": "amari_rewrite_macros",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite_macros",
+              "declaration_ident": "term"
+            }
+          ]
+        }
+      ],
+      "macros": [
+        {
+          "path": "amari_rewrite_macros::Rewritable",
+          "name": "Rewritable",
+          "kind": "proc_macro_derive",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+          "helpers": [
+            "rewritable"
+          ]
+        },
+        {
+          "path": "amari_rewrite_macros::relation",
+          "name": "relation",
+          "kind": "proc_macro",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "signature": "pub fn relation (_input : TokenStream) -> TokenStream"
+        },
+        {
+          "path": "amari_rewrite_macros::rule",
+          "name": "rule",
+          "kind": "proc_macro",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "signature": "pub fn rule (_input : TokenStream) -> TokenStream"
+        },
+        {
+          "path": "amari_rewrite_macros::term",
+          "name": "term",
+          "kind": "proc_macro",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "signature": "pub fn term (_input : TokenStream) -> TokenStream"
+        }
+      ],
+      "cfg_gates": [
+        {
+          "path": "amari_rewrite_macros::derive_rewritable",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite_macros::relation",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite_macros::rule",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite_macros::term",
+          "source_path": "amari-rewrite-macros/src/lib.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        }
+      ],
+      "examples": [],
+      "modules": [
+        "amari_rewrite_macros"
+      ]
     },
     {
       "name": "amari-surcomplex",
@@ -465342,6 +465240,10 @@
     {
       "from": "amari-rewrite",
       "to": "amari-network"
+    },
+    {
+      "from": "amari-rewrite",
+      "to": "amari-rewrite-macros"
     },
     {
       "from": "amari-surcomplex",

--- a/amari-discovery/tests/catalog_generation.rs
+++ b/amari-discovery/tests/catalog_generation.rs
@@ -19,6 +19,7 @@ fn canonical_json(catalog: &StructuralCatalog) -> serde_json::Result<Vec<u8>> {
 /// Crates that legitimately have zero declared Cargo features.
 const ALLOWED_NO_FEATURES: &[&str] = &[
     "amari-discovery-macros",
+    "amari-rewrite-macros",
     "amari-flynn-macros",
     "amari-surcomplex",
     "amari-wasm",
@@ -66,7 +67,7 @@ fn generate_twice_produces_identical_results() {
 }
 
 #[test]
-fn generated_catalog_has_27_packages_excluding_discovery() {
+fn generated_catalog_has_28_packages_excluding_discovery() {
     let catalog = generate_workspace_catalog(workspace_root()).unwrap();
 
     let names: BTreeSet<&str> = catalog.crates.iter().map(|c| c.name.as_str()).collect();
@@ -74,7 +75,7 @@ fn generated_catalog_has_27_packages_excluding_discovery() {
         !names.contains("amari-discovery"),
         "amari-discovery must be excluded"
     );
-    assert_eq!(catalog.crates.len(), 27, "expected 27 workspace packages");
+    assert_eq!(catalog.crates.len(), 28, "expected 28 workspace packages");
 
     // Verify known packages are present.
     for expected in &[
@@ -83,6 +84,7 @@ fn generated_catalog_has_27_packages_excluding_discovery() {
         "amari-tropical",
         "amari-dual",
         "amari-network",
+        "amari-rewrite-macros",
         "amari-optimization",
         "amari-holographic",
         "amari-cgt",

--- a/amari-discovery/tests/catalog_packages.rs
+++ b/amari-discovery/tests/catalog_packages.rs
@@ -85,6 +85,7 @@ fn real_inventory_includes_root_and_wasm_but_excludes_discovery() {
             "amari-probabilistic",
             "amari-relativistic",
             "amari-rewrite",
+            "amari-rewrite-macros",
             "amari-surcomplex",
             "amari-surreal",
             "amari-topology",
@@ -127,7 +128,7 @@ fn real_inventory_includes_root_and_wasm_but_excludes_discovery() {
     for package in &inventory.packages {
         if !matches!(
             package.name.as_str(),
-            "amari-wasm" | "amari-flynn-macros" | "amari-discovery-macros"
+            "amari-wasm" | "amari-flynn-macros" | "amari-discovery-macros" | "amari-rewrite-macros"
         ) {
             assert_eq!(package.library_outputs, ["lib"], "{} targets", package.name);
         }

--- a/amari-rewrite-macros/Cargo.toml
+++ b/amari-rewrite-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "amari-rewrite-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository = "https://github.com/Industrial-Algebra/Amari"
+description = "Checked procedural macros for amari-rewrite: derive(Rewritable), term!/rule!/relation! constructors"
+keywords = ["rewriting", "macros", "term-rewriting", "inverse-rewriting"]
+categories = ["development-tools::procedural-macro-helpers"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-crate = { workspace = true }
+
+[dev-dependencies]
+trybuild = "1"

--- a/amari-rewrite-macros/src/lib.rs
+++ b/amari-rewrite-macros/src/lib.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Checked procedural macros for `amari-rewrite`.
+//!
+//! This crate is the only procedural-macro surface for the rewrite engine.
+//! Algorithms stay in `amari-rewrite`; this crate contains parsing and code
+//! generation only, so the macro crate never depends on the library crate
+//! and always publishes before it.
+//!
+//! # Surface (0.25 scaffold)
+//!
+//! - `#[derive(Rewritable)]` — generates `Rewritable` implementations for
+//!   enum expression trees with explicit `#[rewritable(child)]` fields.
+//! - `term!(f(a, X))` — checked `trs::Term` construction.
+//! - `rule!(lhs => rhs)` — checked `trs::Rule` construction.
+//! - `relation!(lhs <=> rhs)` — checked relational construction.
+//!
+//! Entry points currently expand to stable `compile_error!` diagnostics
+//! naming the implementing task; checked expansion lands in Tasks 4–5 of the
+//! 0.25 inverse-rewrite expansion plan.
+
+use proc_macro::TokenStream;
+
+fn not_yet(implemented_in: &str) -> TokenStream {
+    let message = format!(
+        "this macro is scaffolded but not yet implemented; checked expansion \
+         lands in {implemented_in} of the amari-rewrite 0.25 expansion plan"
+    );
+    let diagnostic = quote::quote! {
+        ::core::compile_error!(#message);
+    };
+    diagnostic.into()
+}
+
+/// Derive `Rewritable` for an enum expression tree.
+///
+/// Only named-field enums with explicit `#[rewritable(child)]` annotations
+/// will be supported; unsupported shapes will fail at compile time so term
+/// structure cannot silently drift from the checked contract.
+#[proc_macro_derive(Rewritable, attributes(rewritable))]
+pub fn derive_rewritable(_input: TokenStream) -> TokenStream {
+    not_yet("Task 4")
+}
+
+/// Checked `trs::Term` construction: `term!(add(zero, X))`.
+///
+/// Identifier and string symbol spellings are equivalent. Expansion is to
+/// checked constructors; malformed terms are compile errors.
+#[proc_macro]
+pub fn term(_input: TokenStream) -> TokenStream {
+    not_yet("Task 5")
+}
+
+/// Checked `trs::Rule` construction: `rule!(add(zero, X) => X)`.
+///
+/// Resolves the fully qualified TRS rule, not the ARS `Rule` type.
+#[proc_macro]
+pub fn rule(_input: TokenStream) -> TokenStream {
+    not_yet("Task 5")
+}
+
+/// Checked relational construction: `relation!(add(zero, X) <=> X)`.
+///
+/// Expands only to checked declarative constructors for the constrained
+/// rewrite-relation model (Cohort 2).
+#[proc_macro]
+pub fn relation(_input: TokenStream) -> TokenStream {
+    not_yet("Cohort 2")
+}

--- a/amari-rewrite/Cargo.toml
+++ b/amari-rewrite/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, optional = true }
 sha2 = { workspace = true }
 amari-network = { workspace = true, optional = true }
 amari-holographic = { workspace = true, optional = true }
+amari-rewrite-macros = { workspace = true, optional = true }
 candle-core = { version = "=0.11.0", optional = true }
 candle-nn = { version = "=0.11.0", optional = true }
 z3 = { version = "=0.20.2", default-features = false, features = ["vendored"], optional = true }
@@ -25,7 +26,7 @@ z3 = { version = "=0.20.2", default-features = false, features = ["vendored"], o
 default = ["std"]
 std = []
 serialize = ["dep:serde"]
-macros = []
+macros = ["dep:amari-rewrite-macros"]
 smt = ["std", "dep:z3"]
 neural = ["std", "dep:candle-core", "dep:candle-nn"]
 network = ["std", "neural", "dep:amari-network"]

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -27,3 +27,6 @@ pub mod smt;
 
 #[cfg(feature = "network")]
 pub mod network;
+
+#[cfg(feature = "macros")]
+pub use amari_rewrite_macros::{relation, rule, term, Rewritable};

--- a/amari-rewrite/tests/macros_reexport.rs
+++ b/amari-rewrite/tests/macros_reexport.rs
@@ -1,0 +1,28 @@
+//! Macro crate wiring proofs (0.25 Cohort 1, Task 3).
+//!
+//! Under the `macros` feature, `amari-rewrite` re-exports the procedural
+//! macro surface from `amari-rewrite-macros`. Without the feature, the macro
+//! crate must not be compiled at all (proved by dependency-tree checks in CI
+//! review evidence; this file compiles to nothing without `macros`).
+
+#![cfg(feature = "macros")]
+
+/// The derive macro is re-exported at the crate root so user code can write
+/// `#[derive(amari_rewrite::Rewritable)]` without depending on the macro
+/// crate directly.
+#[test]
+fn rewritable_derive_is_reexported() {
+    // Existence proof: naming the derive macro as an item path compiles only
+    // if the re-export exists. Invoking it on user types arrives in Task 4.
+    #[allow(unused)]
+    use amari_rewrite::Rewritable;
+}
+
+/// The checked constructor macros are re-exported at the crate root.
+#[test]
+fn constructor_macros_are_reexported() {
+    // Existence proof via macro namespace paths. Checked expansion behavior
+    // arrives in Task 5.
+    #[allow(unused)]
+    use amari_rewrite::{relation, rule, term};
+}


### PR DESCRIPTION
# 0.25 Cohort 1, Task 3: scaffold `amari-rewrite-macros`

Per the [approved plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md) and [design](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-design.md): one publishable proc-macro crate holds all procedural macros; algorithms stay in `amari-rewrite`; the macro crate never depends on the library and **publishes first** (tier 0).

## What

- **New crate** `amari-rewrite-macros` (workspace metadata inherited, `proc-macro = true`, syn/quote/proc-macro2 + `proc-macro-crate = "3"` for renamed-crate support in Tasks 4–5).
- **Entry points with stable `compile_error!` diagnostics** naming their implementing task — verified at a use site:
  - `#[derive(Rewritable)]` → "lands in **Task 4**"
  - `term!` / `rule!` → "lands in **Task 5**"
  - `relation!` → "lands in **Cohort 2**"
- **`amari-rewrite` wiring**: `macros = ["dep:amari-rewrite-macros"]`; root re-export `use amari_rewrite::{Rewritable, term, rule, relation}` — the derive shares the `Rewritable` trait name across namespaces (serde-style), so `#[derive(amari_rewrite::Rewritable)]` will work as designed.
- **Publish workflow**: tier 0 gains `amari-rewrite-macros` (with the other macro crates).
- **Structural catalog**: regenerated — 28 crates, 106 edges, hash `334b1b19…`; count-pinned catalog test 27→28; `ALLOWED_NO_FEATURES` extended; `catalog_packages` exact-name list + proc-macro `library_outputs` exemption extended (second commit, caught by Discovery Catalog shard; full local sweep: 20+11+32 suites green).

## Evidence

- **RED**: `macros_reexport.rs` failed pre-scaffold (`E0432` unresolved imports) ✓
- **GREEN**: wiring tests 2/2; diagnostic verified end-to-end from a scratch consumer crate ✓
- **Tree proofs**: default & no-default trees compile **zero** macro crates; `--features macros` adds exactly one; macro crate has **no** dep back on `amari-rewrite` ✓
- 14/14 `amari-rewrite` suites with `--all-features` (+1 new); `cargo +1.89.0 check --workspace` PASS
- Verifiers: version-sync 0.24.1, publish-order (**9 tiers / 28 crates**, dependency-safe), workflow-crates, discovery sharding, binary-owner — all PASS
- Clippy `-D warnings` under **both** CI invocations (native-precision + all-targets/all-features); fmt clean
- `cargo publish --dry-run -p amari-rewrite-macros` packaged (5 files, 11.6 KiB) on publish toolchain 1.97.1; WASM surface unchanged

## Not in this PR

Task 4 (`derive(Rewritable)` real expansion) and Task 5 (checked `term!`/`rule!` + trybuild UI fixtures) — the placeholders' diagnostics name them.
