### PR TITLE
feat: derive rewritable structures (0.25 Cohort 1, Task 4)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "version": "0.24.1",
-  "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 106 dependency edges",
-  "content_hash": "334b1b19cde09b1b2a7544f819de3385ead52a98e53800ae3c01807b325b2de0",
+  "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
+  "content_hash": "a7d6a0b5981f558315dc1f16871da1410f789b53a8a658ef2527623f14bd7bb6",
   "crates": [
     {
       "name": "amari",
@@ -382364,6 +382364,14 @@
           ]
         },
         {
+          "alias": "amari-rewrite",
+          "package": "amari-rewrite",
+          "kind": "development",
+          "path": "../amari-rewrite",
+          "optional": false,
+          "default_features": true
+        },
+        {
           "alias": "trybuild",
           "package": "trybuild",
           "kind": "development",
@@ -382386,14 +382394,14 @@
         {
           "path": "amari_rewrite_macros::derive_rewritable",
           "kind": "fn",
-          "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+          "signature": "pub fn derive_rewritable (input : TokenStream) -> TokenStream",
           "source_path": "amari-rewrite-macros/src/lib.rs",
           "is_reexport": false,
           "source_module": "amari_rewrite_macros",
           "variants": [
             {
               "kind": "fn",
-              "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+              "signature": "pub fn derive_rewritable (input : TokenStream) -> TokenStream",
               "source_path": "amari-rewrite-macros/src/lib.rs",
               "source_module": "amari_rewrite_macros",
               "is_reexport": false,
@@ -382466,7 +382474,7 @@
           "name": "Rewritable",
           "kind": "proc_macro_derive",
           "source_path": "amari-rewrite-macros/src/lib.rs",
-          "signature": "pub fn derive_rewritable (_input : TokenStream) -> TokenStream",
+          "signature": "pub fn derive_rewritable (input : TokenStream) -> TokenStream",
           "helpers": [
             "rewritable"
           ]
@@ -465244,6 +465252,10 @@
     {
       "from": "amari-rewrite",
       "to": "amari-rewrite-macros"
+    },
+    {
+      "from": "amari-rewrite-macros",
+      "to": "amari-rewrite"
     },
     {
       "from": "amari-surcomplex",

--- a/amari-rewrite-macros/Cargo.toml
+++ b/amari-rewrite-macros/Cargo.toml
@@ -21,3 +21,4 @@ proc-macro-crate = { workspace = true }
 
 [dev-dependencies]
 trybuild = "1"
+amari-rewrite = { path = "../amari-rewrite" }

--- a/amari-rewrite-macros/src/lib.rs
+++ b/amari-rewrite-macros/src/lib.rs
@@ -7,19 +7,19 @@
 //! generation only, so the macro crate never depends on the library crate
 //! and always publishes before it.
 //!
-//! # Surface (0.25 scaffold)
+//! - `#[derive(Rewritable)]` — generates `Rewritable` implementations
+//!   for structs and enums with explicit `#[rewritable(child)]` fields.
+//! - `term!(f(a, X))` — checked `trs::Term` construction (Task 5).
+//! - `rule!(lhs => rhs)` — checked `trs::Rule` construction (Task 5).
+//! - `relation!(lhs <=> rhs)` — checked relational construction
+//!   (Cohort 2).
 //!
-//! - `#[derive(Rewritable)]` — generates `Rewritable` implementations for
-//!   enum expression trees with explicit `#[rewritable(child)]` fields.
-//! - `term!(f(a, X))` — checked `trs::Term` construction.
-//! - `rule!(lhs => rhs)` — checked `trs::Rule` construction.
-//! - `relation!(lhs <=> rhs)` — checked relational construction.
-//!
-//! Entry points currently expand to stable `compile_error!` diagnostics
-//! naming the implementing task; checked expansion lands in Tasks 4–5 of the
-//! 0.25 inverse-rewrite expansion plan.
+//! Entry points marked with a task expand to stable `compile_error!`
+//! diagnostics naming the implementing task until they land.
 
 use proc_macro::TokenStream;
+
+mod rewritable_derive;
 
 fn not_yet(implemented_in: &str) -> TokenStream {
     let message = format!(
@@ -32,14 +32,19 @@ fn not_yet(implemented_in: &str) -> TokenStream {
     diagnostic.into()
 }
 
-/// Derive `Rewritable` for an enum expression tree.
+/// Derive `Rewritable` for an expression tree.
 ///
-/// Only named-field enums with explicit `#[rewritable(child)]` annotations
-/// will be supported; unsupported shapes will fail at compile time so term
-/// structure cannot silently drift from the checked contract.
+/// Children are exactly the fields marked `#[rewritable(child)]`, in
+/// declaration order; recursion is never inferred. A child field's type
+/// must deref to `Self` and rebuild from `Self` (`Box<Self>`,
+/// `Rc<Self>`, `Arc<Self>`); unmarked fields are cloned through
+/// replacement and must be `Clone`. Unions, generics, collections as
+/// children, and malformed attributes are compile errors at precise
+/// spans.
 #[proc_macro_derive(Rewritable, attributes(rewritable))]
-pub fn derive_rewritable(_input: TokenStream) -> TokenStream {
-    not_yet("Task 4")
+pub fn derive_rewritable(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    rewritable_derive::expand(input).into()
 }
 
 /// Checked `trs::Term` construction: `term!(add(zero, X))`.

--- a/amari-rewrite-macros/src/rewritable_derive.rs
+++ b/amari-rewrite-macros/src/rewritable_derive.rs
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `derive(Rewritable)` implementation.
+//!
+//! Supported containers: named/tuple/unit structs and enums whose
+//! variants use named, tuple, or unit shapes. Children are exactly the
+//! fields marked `#[rewritable(child)]`, in declaration order; the
+//! macro never infers recursion. A child field's type must deref to
+//! `Self` and rebuild from `Self` (`Box<Self>`, `Rc<Self>`, `Arc<Self>`).
+//! Unmarked fields are cloned through replacement and must be `Clone`.
+//!
+//! Rejected with precise spans: unions, generic parameters, duplicate
+//! or unknown `#[rewritable(...)]` arguments, and collection-typed
+//! children (`Vec` and friends — use one child field per position).
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Error, Fields, Ident, Index, Member, Type};
+
+/// Expand the derive; parse/shape errors become `compile_error!`.
+pub fn expand(input: DeriveInput) -> TokenStream {
+    match plan(&input).and_then(|ctors| generate(&input, &ctors)) {
+        Ok(tokens) => tokens,
+        Err(error) => error.into_compile_error(),
+    }
+}
+
+/// One constructor's shape: the struct itself or one enum variant.
+struct Constructor {
+    /// Pattern/construction path: `Self` or `Self::Variant`.
+    path: TokenStream,
+    fields: Vec<FieldPlan>,
+}
+
+struct FieldPlan {
+    member: Member,
+    binding: Ident,
+    is_child: bool,
+}
+
+fn plan(input: &DeriveInput) -> Result<Vec<Constructor>, Error> {
+    if !input.generics.params.is_empty() {
+        return Err(Error::new(
+            input.generics.span(),
+            "derive(Rewritable) does not support generic parameters",
+        ));
+    }
+    match &input.data {
+        Data::Union(data) => Err(Error::new(
+            data.fields.span(),
+            "derive(Rewritable) does not support unions",
+        )),
+        Data::Struct(data) => Ok(vec![Constructor {
+            path: quote!(Self),
+            fields: plan_fields(&data.fields)?,
+        }]),
+        Data::Enum(data) => data
+            .variants
+            .iter()
+            .map(|variant| {
+                let ident = &variant.ident;
+                Ok(Constructor {
+                    path: quote!(Self::#ident),
+                    fields: plan_fields(&variant.fields)?,
+                })
+            })
+            .collect(),
+    }
+}
+
+fn plan_fields(fields: &Fields) -> Result<Vec<FieldPlan>, Error> {
+    let mut planned = Vec::new();
+    for (position, field) in fields.iter().enumerate() {
+        let (member, binding) = match &field.ident {
+            Some(ident) => (Member::Named(ident.clone()), ident.clone()),
+            None => (
+                Member::Unnamed(Index::from(position)),
+                format_ident!("__rewritable_field_{position}"),
+            ),
+        };
+        let is_child = child_attribute(field)?;
+        if is_child {
+            reject_collection(&field.ty)?;
+        }
+        planned.push(FieldPlan {
+            member,
+            binding,
+            is_child,
+        });
+    }
+    Ok(planned)
+}
+
+/// Parse `#[rewritable(child)]`; reject duplicates and unknown keys.
+fn child_attribute(field: &syn::Field) -> Result<bool, Error> {
+    let mut child = false;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("rewritable") {
+            continue;
+        }
+        if matches!(attr.meta, syn::Meta::Path(_)) {
+            return Err(Error::new(attr.span(), "expected `#[rewritable(child)]`"));
+        }
+        let mut seen_here = false;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("child") {
+                if seen_here {
+                    return Err(meta.error("duplicate `child` in rewritable attribute"));
+                }
+                seen_here = true;
+                Ok(())
+            } else {
+                Err(meta.error("unsupported rewritable argument; expected `child`"))
+            }
+        })?;
+        if seen_here {
+            if child {
+                return Err(Error::new(
+                    attr.span(),
+                    "duplicate `#[rewritable(child)]` on one field",
+                ));
+            }
+            child = true;
+        }
+    }
+    Ok(child)
+}
+
+/// Collection-typed children get a targeted diagnostic; the trait
+/// models children as individual positions, not containers.
+fn reject_collection(ty: &Type) -> Result<(), Error> {
+    let Type::Path(path) = ty else {
+        return Ok(());
+    };
+    let Some(segment) = path.path.segments.last() else {
+        return Ok(());
+    };
+    const COLLECTIONS: &[&str] = &[
+        "Vec",
+        "VecDeque",
+        "LinkedList",
+        "HashSet",
+        "BTreeSet",
+        "HashMap",
+        "BTreeMap",
+        "BinaryHeap",
+    ];
+    if COLLECTIONS.iter().any(|c| segment.ident == c) {
+        return Err(Error::new(
+            ty.span(),
+            "collection-typed children are not supported by \
+             derive(Rewritable); use one child field per position",
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve `amari-rewrite` for hygienic generated paths. `Itself`
+/// (expansion inside amari-rewrite's own targets) still uses
+/// `::amari_rewrite`, valid through `extern crate self as amari_rewrite`
+/// plus the implicit extern in integration/doc targets.
+fn rewrite_path() -> TokenStream {
+    let found = proc_macro_crate::crate_name("amari-rewrite");
+    match found {
+        Ok(proc_macro_crate::FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, proc_macro2::Span::call_site());
+            quote!(::#ident)
+        }
+        _ => quote!(::amari_rewrite),
+    }
+}
+
+fn generate(input: &DeriveInput, constructors: &[Constructor]) -> Result<TokenStream, Error> {
+    let name = &input.ident;
+    let rewrite = rewrite_path();
+
+    if constructors.is_empty() {
+        // Uninhabited enum: empty matches diverge and typecheck.
+        return Ok(quote! {
+            #[automatically_derived]
+            impl #rewrite::Rewritable for #name {
+                fn child_count(&self) -> usize {
+                    match *self {}
+                }
+                fn child(
+                    &self,
+                    _index: usize,
+                ) -> ::core::option::Option<&Self> {
+                    match *self {}
+                }
+                fn replace_child(
+                    &self,
+                    _index: usize,
+                    _replacement: Self,
+                ) -> #rewrite::RewriteResult<Self> {
+                    match *self {}
+                }
+            }
+        });
+    }
+
+    let count_arms = constructors.iter().map(count_arm);
+    let child_arms = constructors.iter().map(child_arm);
+    let replace_arms = constructors.iter().map(|c| replace_arm(c, &rewrite));
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #rewrite::Rewritable for #name {
+            fn child_count(&self) -> usize {
+                match self {
+                    #(#count_arms)*
+                }
+            }
+            fn child(
+                &self,
+                index: usize,
+            ) -> ::core::option::Option<&Self> {
+                match self {
+                    #(#child_arms)*
+                }
+            }
+            fn replace_child(
+                &self,
+                index: usize,
+                replacement: Self,
+            ) -> #rewrite::RewriteResult<Self> {
+                match self {
+                    #(#replace_arms)*
+                }
+            }
+        }
+    })
+}
+
+/// `Constructor { .. } => <child count>` (unit: `Constructor => 0`).
+fn count_arm(constructor: &Constructor) -> TokenStream {
+    let path = &constructor.path;
+    let count = constructor.fields.iter().filter(|f| f.is_child).count();
+    let pattern = ignored_pattern(constructor);
+    quote!(#path #pattern => #count,)
+}
+
+fn ignored_pattern(constructor: &Constructor) -> TokenStream {
+    match constructor.fields.first() {
+        None => quote!(),
+        Some(field) => match &field.member {
+            Member::Named(_) => quote!({ .. }),
+            Member::Unnamed(_) => quote!((..)),
+        },
+    }
+}
+
+/// Bind child fields, dispatch on `index`.
+fn child_arm(constructor: &Constructor) -> TokenStream {
+    let path = &constructor.path;
+    let children: Vec<&FieldPlan> = constructor.fields.iter().filter(|f| f.is_child).collect();
+    if children.is_empty() {
+        let pattern = ignored_pattern(constructor);
+        return quote!(#path #pattern => ::core::option::Option::None,);
+    }
+    let bindings: Vec<&Ident> = children.iter().map(|f| &f.binding).collect();
+    let pattern = child_pattern(constructor, &bindings);
+    let arms = children.iter().enumerate().map(|(index, field)| {
+        let binding = &field.binding;
+        quote! {
+            #index => ::core::option::Option::Some(
+                ::core::ops::Deref::deref(#binding)
+            ),
+        }
+    });
+    quote! {
+        #path #pattern => match index {
+            #(#arms)*
+            _ => ::core::option::Option::None,
+        },
+    }
+}
+
+fn child_pattern(constructor: &Constructor, bindings: &[&Ident]) -> TokenStream {
+    match constructor.fields.first() {
+        None => quote!(),
+        Some(field) => match &field.member {
+            Member::Named(_) => quote!({ #(#bindings,)* .. }),
+            Member::Unnamed(_) => {
+                let slots = constructor.fields.iter().map(|f| {
+                    if f.is_child {
+                        let binding = &f.binding;
+                        quote!(#binding)
+                    } else {
+                        quote!(_)
+                    }
+                });
+                quote!(( #(#slots),* ))
+            }
+        },
+    }
+}
+
+/// Bind all fields, rebuild with one child swapped via `From`.
+fn replace_arm(constructor: &Constructor, rewrite: &TokenStream) -> TokenStream {
+    let path = &constructor.path;
+    let has_children = constructor.fields.iter().any(|f| f.is_child);
+    if constructor.fields.is_empty() || !has_children {
+        let pattern = ignored_pattern(constructor);
+        return quote! {
+            #path #pattern => ::core::result::Result::Err(
+                #rewrite::RewriteError::InvalidChildIndex { index }
+            ),
+        };
+    }
+    let bindings: Vec<&Ident> = constructor.fields.iter().map(|f| &f.binding).collect();
+    let pattern = full_pattern(constructor, &bindings);
+
+    let mut child_index = 0usize;
+    let mut arms = Vec::new();
+    for field in &constructor.fields {
+        if !field.is_child {
+            continue;
+        }
+        let constructions = constructor.fields.iter().map(|f| {
+            let member = &f.member;
+            let binding = &f.binding;
+            if std::ptr::eq(f, field) {
+                construct_field(
+                    member,
+                    quote! {
+                        ::core::convert::From::from(replacement)
+                    },
+                )
+            } else {
+                construct_field(
+                    member,
+                    quote! {
+                        ::core::clone::Clone::clone(#binding)
+                    },
+                )
+            }
+        });
+        let body = construct_body(constructor, constructions);
+        arms.push(quote!(#child_index => ::core::result::Result::Ok(#body),));
+        child_index += 1;
+    }
+
+    quote! {
+        #path #pattern => match index {
+            #(#arms)*
+            _ => ::core::result::Result::Err(
+                #rewrite::RewriteError::InvalidChildIndex { index }
+            ),
+        },
+    }
+}
+
+fn full_pattern(constructor: &Constructor, bindings: &[&Ident]) -> TokenStream {
+    match constructor.fields.first().map(|f| &f.member) {
+        None => quote!(),
+        Some(Member::Named(_)) => quote!({ #(#bindings),* }),
+        Some(Member::Unnamed(_)) => quote!(( #(#bindings),* )),
+    }
+}
+
+fn construct_field(member: &Member, value: TokenStream) -> TokenStream {
+    match member {
+        Member::Named(ident) => quote!(#ident: #value),
+        Member::Unnamed(_) => quote!(#value),
+    }
+}
+
+fn construct_body(
+    constructor: &Constructor,
+    fields: impl Iterator<Item = TokenStream>,
+) -> TokenStream {
+    let path = &constructor.path;
+    let fields: Vec<TokenStream> = fields.collect();
+    match constructor.fields.first().map(|f| &f.member) {
+        None => quote!(#path),
+        Some(Member::Named(_)) => quote!(#path { #(#fields),* }),
+        Some(Member::Unnamed(_)) => quote!(#path ( #(#fields),* )),
+    }
+}

--- a/amari-rewrite-macros/src/rewritable_derive.rs
+++ b/amari-rewrite-macros/src/rewritable_derive.rs
@@ -41,8 +41,17 @@ struct FieldPlan {
 
 fn plan(input: &DeriveInput) -> Result<Vec<Constructor>, Error> {
     if !input.generics.params.is_empty() {
+        // Single-token span: trybuild .stderr files must render
+        // identically across rustc patch versions (joined spans render
+        // first-token-only on some toolchains).
+        let span = input
+            .generics
+            .params
+            .first()
+            .map(Spanned::span)
+            .unwrap_or_else(|| input.generics.span());
         return Err(Error::new(
-            input.generics.span(),
+            span,
             "derive(Rewritable) does not support generic parameters",
         ));
     }
@@ -117,7 +126,7 @@ fn child_attribute(field: &syn::Field) -> Result<bool, Error> {
         if seen_here {
             if child {
                 return Err(Error::new(
-                    attr.span(),
+                    attr.path().span(),
                     "duplicate `#[rewritable(child)]` on one field",
                 ));
             }
@@ -148,7 +157,7 @@ fn reject_collection(ty: &Type) -> Result<(), Error> {
     ];
     if COLLECTIONS.iter().any(|c| segment.ident == c) {
         return Err(Error::new(
-            ty.span(),
+            segment.ident.span(),
             "collection-typed children are not supported by \
              derive(Rewritable); use one child field per position",
         ));

--- a/amari-rewrite-macros/tests/renamed/Cargo.toml
+++ b/amari-rewrite-macros/tests/renamed/Cargo.toml
@@ -1,0 +1,15 @@
+# Renamed-crate fixture: depends on amari-rewrite under the alias
+# `rewrite_lib` so generated `::rewrite_lib::...` paths are exercised.
+# Detached from the Amari workspace by the empty [workspace] table.
+
+[package]
+name = "amari-rewrite-renamed-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+amari-rewrite-macros = { path = "../.." }
+rewrite_lib = { package = "amari-rewrite", path = "../../../amari-rewrite" }

--- a/amari-rewrite-macros/tests/renamed/src/main.rs
+++ b/amari-rewrite-macros/tests/renamed/src/main.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The derive must resolve `amari-rewrite` through the user's chosen
+//! dependency name (`rewrite_lib` here) via proc-macro-crate.
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Zero,
+    Succ(#[rewritable(child)] Box<Expr>),
+}
+
+fn main() {
+    let one = Expr::Succ(Box::new(Expr::Zero));
+    assert_eq!(rewrite_lib::Rewritable::child_count(&one), 1);
+    assert_eq!(
+        rewrite_lib::Rewritable::child(&one, 0),
+        Some(&Expr::Zero)
+    );
+}

--- a/amari-rewrite-macros/tests/ui.rs
+++ b/amari-rewrite-macros/tests/ui.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! UI contracts for `derive(Rewritable)`: diagnostics, hygiene, and
+//! renamed-crate support. `term!`/`rule!` fixtures arrive in Task 5.
+
+#[test]
+fn rewritable_ui() {
+    let cases = trybuild::TestCases::new();
+    cases.pass("tests/ui/pass_enum.rs");
+    cases.pass("tests/ui/pass_struct_children.rs");
+    cases.compile_fail("tests/ui/fail_union.rs");
+    cases.compile_fail("tests/ui/fail_generic.rs");
+    cases.compile_fail("tests/ui/fail_duplicate_child.rs");
+    cases.compile_fail("tests/ui/fail_unknown_attribute.rs");
+    cases.compile_fail("tests/ui/fail_collection_child.rs");
+}
+
+/// Renamed-crate support: the fixture under `tests/renamed` depends on
+/// `amari-rewrite` as `rewrite_lib`; proc-macro-crate must resolve the
+/// alias. Compiled with the real cargo against path dependencies.
+#[test]
+fn renamed_crate_fixture_compiles() {
+    use std::path::PathBuf;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = manifest_dir.join("tests/renamed");
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest_dir.join("../target"));
+
+    let status = std::process::Command::new(env!("CARGO"))
+        .args(["check", "--offline"])
+        .current_dir(&fixture)
+        .env("CARGO_TARGET_DIR", target_dir)
+        .status()
+        .expect("cargo check for renamed fixture should launch");
+    assert!(status.success(), "renamed-crate fixture must compile");
+}

--- a/amari-rewrite-macros/tests/ui/fail_collection_child.rs
+++ b/amari-rewrite-macros/tests/ui/fail_collection_child.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Zero,
+    Many(#[rewritable(child)] Vec<Expr>),
+}
+
+fn main() {}

--- a/amari-rewrite-macros/tests/ui/fail_collection_child.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_collection_child.stderr
@@ -1,0 +1,5 @@
+error: collection-typed children are not supported by derive(Rewritable); use one child field per position
+ --> tests/ui/fail_collection_child.rs:8:31
+  |
+8 |     Many(#[rewritable(child)] Vec<Expr>),
+  |                               ^^^^^^^^^

--- a/amari-rewrite-macros/tests/ui/fail_collection_child.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_collection_child.stderr
@@ -2,4 +2,4 @@ error: collection-typed children are not supported by derive(Rewritable); use on
  --> tests/ui/fail_collection_child.rs:8:31
   |
 8 |     Many(#[rewritable(child)] Vec<Expr>),
-  |                               ^^^^^^^^^
+  |                               ^^^

--- a/amari-rewrite-macros/tests/ui/fail_duplicate_child.rs
+++ b/amari-rewrite-macros/tests/ui/fail_duplicate_child.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Zero,
+    Succ(
+        #[rewritable(child)]
+        #[rewritable(child)]
+        Box<Expr>,
+    ),
+}
+
+fn main() {}

--- a/amari-rewrite-macros/tests/ui/fail_duplicate_child.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_duplicate_child.stderr
@@ -1,0 +1,5 @@
+error: duplicate `#[rewritable(child)]` on one field
+  --> tests/ui/fail_duplicate_child.rs:10:9
+   |
+10 |         #[rewritable(child)]
+   |         ^^^^^^^^^^^^^^^^^^^^

--- a/amari-rewrite-macros/tests/ui/fail_duplicate_child.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_duplicate_child.stderr
@@ -1,5 +1,5 @@
 error: duplicate `#[rewritable(child)]` on one field
-  --> tests/ui/fail_duplicate_child.rs:10:9
+  --> tests/ui/fail_duplicate_child.rs:10:11
    |
 10 |         #[rewritable(child)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^

--- a/amari-rewrite-macros/tests/ui/fail_generic.rs
+++ b/amari-rewrite-macros/tests/ui/fail_generic.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+struct Wrapper<T> {
+    value: T,
+}
+
+fn main() {}

--- a/amari-rewrite-macros/tests/ui/fail_generic.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_generic.stderr
@@ -1,5 +1,5 @@
 error: derive(Rewritable) does not support generic parameters
- --> tests/ui/fail_generic.rs:6:15
+ --> tests/ui/fail_generic.rs:6:16
   |
 6 | struct Wrapper<T> {
-  |               ^^^
+  |                ^

--- a/amari-rewrite-macros/tests/ui/fail_generic.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_generic.stderr
@@ -1,0 +1,5 @@
+error: derive(Rewritable) does not support generic parameters
+ --> tests/ui/fail_generic.rs:6:15
+  |
+6 | struct Wrapper<T> {
+  |               ^^^

--- a/amari-rewrite-macros/tests/ui/fail_union.rs
+++ b/amari-rewrite-macros/tests/ui/fail_union.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Rewritable)]
+union Number {
+    integer: u32,
+    float: f32,
+}
+
+fn main() {}

--- a/amari-rewrite-macros/tests/ui/fail_union.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_union.stderr
@@ -1,0 +1,9 @@
+error: derive(Rewritable) does not support unions
+ --> tests/ui/fail_union.rs:6:14
+  |
+6 |   union Number {
+  |  ______________^
+7 | |     integer: u32,
+8 | |     float: f32,
+9 | | }
+  | |_^

--- a/amari-rewrite-macros/tests/ui/fail_unknown_attribute.rs
+++ b/amari-rewrite-macros/tests/ui/fail_unknown_attribute.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Zero,
+    Succ(#[rewritable(children)] Box<Expr>),
+}
+
+fn main() {}

--- a/amari-rewrite-macros/tests/ui/fail_unknown_attribute.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_unknown_attribute.stderr
@@ -1,0 +1,5 @@
+error: unsupported rewritable argument; expected `child`
+ --> tests/ui/fail_unknown_attribute.rs:8:23
+  |
+8 |     Succ(#[rewritable(children)] Box<Expr>),
+  |                       ^^^^^^^^

--- a/amari-rewrite-macros/tests/ui/pass_enum.rs
+++ b/amari-rewrite-macros/tests/ui/pass_enum.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Enum expression tree: unit, tuple, and named-field variants with
+//! unmarked payload fields cloned through replacement.
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Num(i64),
+    Neg(#[rewritable(child)] Box<Expr>),
+    Add {
+        #[rewritable(child)]
+        lhs: Box<Expr>,
+        #[rewritable(child)]
+        rhs: Box<Expr>,
+        note: String,
+    },
+}
+
+fn main() {
+    let tree = Expr::Add {
+        lhs: Box::new(Expr::Num(1)),
+        rhs: Box::new(Expr::Neg(Box::new(Expr::Num(2)))),
+        note: "kept".to_string(),
+    };
+    assert_eq!(amari_rewrite::Rewritable::child_count(&tree), 2);
+    let one = amari_rewrite::Rewritable::child(&tree, 1).unwrap();
+    assert_eq!(amari_rewrite::Rewritable::child_count(one), 1);
+}

--- a/amari-rewrite-macros/tests/ui/pass_struct_children.rs
+++ b/amari-rewrite-macros/tests/ui/pass_struct_children.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Struct shapes: a leaf struct and a tuple struct carrying children
+//! (compile-only; boxed self-recursion cannot terminate at runtime).
+
+use amari_rewrite_macros::Rewritable;
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+struct Meta {
+    name: String,
+    arity: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+struct Pair(
+    #[rewritable(child)] Box<Pair>,
+    #[rewritable(child)] Box<Pair>,
+);
+
+fn main() {
+    let meta = Meta {
+        name: "const".to_string(),
+        arity: 0,
+    };
+    assert_eq!(amari_rewrite::Rewritable::child_count(&meta), 0);
+    let _ = std::mem::size_of::<Pair>();
+}

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -8,6 +8,11 @@
 
 extern crate alloc;
 
+// Lets derive-generated `::amari_rewrite::...` paths resolve inside this
+// crate's own targets (unit tests, examples) where proc-macro-crate
+// reports `Itself`.
+extern crate self as amari_rewrite;
+
 pub mod ars;
 pub mod error;
 pub mod inverse;

--- a/amari-rewrite/tests/macros_derive.rs
+++ b/amari-rewrite/tests/macros_derive.rs
@@ -1,0 +1,137 @@
+//! derive(Rewritable) runtime behavior tests (0.25 Cohort 1, Task 4).
+//!
+//! Exercises the real macro expansion through the public trait surface:
+//! preorder positions, child access, replacement, and checked
+//! invalid-index errors. Compile-time rejection contracts (unions,
+//! generics, duplicate attributes, collections) live in the trybuild
+//! fixtures under `amari-rewrite-macros/tests/ui/`.
+
+#![cfg(feature = "macros")]
+
+use amari_rewrite::{Path, Rewritable, RewriteError};
+
+/// Expression AST mixing a unit leaf, a tuple variant child, and a
+/// struct variant with named children plus an unmarked payload field.
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+enum Expr {
+    Num(i64),
+    Neg(#[rewritable(child)] Box<Expr>),
+    Add {
+        #[rewritable(child)]
+        lhs: Box<Expr>,
+        #[rewritable(child)]
+        rhs: Box<Expr>,
+        note: String,
+    },
+}
+
+fn num(n: i64) -> Expr {
+    Expr::Num(n)
+}
+
+fn add(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::Add {
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+        note: String::new(),
+    }
+}
+
+#[test]
+fn replace_child_preserves_unmarked_payloads() {
+    let tree = Expr::Add {
+        lhs: Box::new(num(1)),
+        rhs: Box::new(num(2)),
+        note: "kept".to_string(),
+    };
+    let replaced = tree.replace_child(1, num(3)).unwrap();
+    match replaced {
+        Expr::Add { lhs, rhs, note } => {
+            assert_eq!(*lhs, num(1));
+            assert_eq!(*rhs, num(3));
+            assert_eq!(note, "kept");
+        }
+        other => panic!("expected Add, got {other:?}"),
+    }
+    let err = tree.replace_child(2, num(3)).unwrap_err();
+    assert_eq!(err, RewriteError::InvalidChildIndex { index: 2 });
+}
+
+/// Leaf struct: no marked children, unmarked payloads only.
+/// (Struct variants carrying children are exercised through `Expr::Add`;
+/// a pure struct with `Box<Self>` children cannot terminate.)
+#[derive(Clone, Debug, PartialEq, Rewritable)]
+struct Meta {
+    name: String,
+    arity: usize,
+}
+
+#[test]
+fn struct_without_children_is_a_leaf() {
+    let meta = Meta {
+        name: "const".to_string(),
+        arity: 0,
+    };
+    assert_eq!(meta.child_count(), 0);
+    assert_eq!(meta.child(0), None);
+    let err = meta
+        .replace_child(
+            0,
+            Meta {
+                name: "other".to_string(),
+                arity: 1,
+            },
+        )
+        .unwrap_err();
+    assert_eq!(err, RewriteError::InvalidChildIndex { index: 0 });
+}
+
+#[test]
+fn leaf_variants_have_no_children() {
+    let leaf = num(7);
+    assert_eq!(leaf.child_count(), 0);
+    assert_eq!(leaf.child(0), None);
+    let err = leaf.replace_child(0, num(8)).unwrap_err();
+    assert_eq!(err, RewriteError::InvalidChildIndex { index: 0 });
+}
+
+#[test]
+fn tuple_variant_children_are_positional() {
+    let neg = Expr::Neg(Box::new(num(1)));
+    assert_eq!(neg.child_count(), 1);
+    assert_eq!(neg.child(0), Some(&num(1)));
+    assert_eq!(neg.child(1), None);
+    let replaced = neg.replace_child(0, num(2)).unwrap();
+    assert_eq!(replaced, Expr::Neg(Box::new(num(2))));
+}
+
+#[test]
+fn struct_variant_children_follow_declaration_order() {
+    let tree = add(num(1), num(2));
+    assert_eq!(tree.child_count(), 2);
+    assert_eq!(tree.child(0), Some(&num(1)));
+    assert_eq!(tree.child(1), Some(&num(2)));
+    assert_eq!(tree.child(2), None);
+}
+
+#[test]
+fn preorder_positions_cover_the_whole_tree() {
+    let tree = add(add(num(1), num(2)), num(3));
+    let expected: Vec<Path> = vec![
+        Path::root(),
+        Path::from([0]),
+        Path::from([0, 0]),
+        Path::from([0, 1]),
+        Path::from([1]),
+    ];
+    assert_eq!(tree.positions(), expected);
+}
+
+#[test]
+fn replace_at_rebuilds_only_the_target_path() {
+    let tree = add(add(num(1), num(2)), num(3));
+    let replaced = tree.replace_at(&Path::from([0, 1]), num(9)).unwrap();
+    assert_eq!(replaced, add(add(num(1), num(9)), num(3)));
+    let err = tree.replace_at(&Path::from([1, 0]), num(9)).unwrap_err();
+    assert_eq!(err, RewriteError::InvalidChildIndex { index: 0 });
+}

--- a/scripts/verify-publish-order.py
+++ b/scripts/verify-publish-order.py
@@ -46,6 +46,12 @@ for name in published:
         errors.append(f"{name}: not a workspace package")
         continue
     for dependency in packages[name]["dependencies"]:
+        # Dev-dependencies do not constrain publish order: path-only
+        # dev-deps are stripped at package time, and versioned dev-deps
+        # never affect downstream resolution of the published crate.
+        # Build dependencies stay (they compile the published crate).
+        if dependency.get("kind") == "dev":
+            continue
         dependency_name = dependency["name"]
         if dependency_name not in tier_of or dependency_name == name:
             continue


### PR DESCRIPTION
# 0.25 Cohort 1, Task 4: `derive(Rewritable)`

Real expansion for the derive scaffolded in #243, per the
[plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md)
and [design](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-design.md).
`term!`/`rule!` (Task 5) and `relation!` (Cohort 2) stay scaffolded with
their stable diagnostics.

## Contract (locked by trybuild UI fixtures)

- **Containers**: named/tuple/unit structs; enums with named/tuple/unit
  variants.
- **Children**: exactly the fields marked `#[rewritable(child)]`, in
  declaration order — recursion is **never inferred**. Child types must
  deref to `Self` and rebuild via `From` (`Box`/`Rc`/`Arc<Self>`);
  unmarked fields clone through replacement (must be `Clone`).
- **Rejected at precise spans**: unions, generics, duplicate
  `#[rewritable(child)]`, unknown `#[rewritable(...)]` keys (span on the
  offending key), collection-typed children (`Vec` etc. — targeted
  message: one child field per position).
- Exhaustive per-constructor matches; `replace_child` returns checked
  `RewriteError::InvalidChildIndex`; generated paths fully qualified.
- **Renamed crates** via `proc-macro-crate`; `Itself` resolves to
  `::amari_rewrite` (backed by `extern crate self as amari_rewrite`).

## Supporting change: publish-order verifier

`scripts/verify-publish-order.py` now skips **dev-dependencies** when
checking tier safety. This is an accuracy fix, not a weakening:

- Path-only dev-deps are **stripped at package time** — evidence: the
  packaged manifest `target/package/amari-rewrite-macros-0.24.1/Cargo.toml`
  retains only `trybuild` under `[dev-dependencies]`; the `amari-rewrite`
  dev-dep is absent.
- Versioned dev-deps never affect downstream resolution.
- **Build deps still count** (they compile the published crate).
- The macros crate's published graph is unchanged: tier 0, before
  `amari-rewrite`. The dev edge appears only in the structural catalog
  (107 edges), which records all dependency kinds by design.

## Evidence

- **RED** → placeholder error + missing trait methods; **GREEN** after
  implementation.
- **7/7 runtime tests** (`macros_derive.rs`): preorder positions, child
  access/replacement, invalid-index errors, payload preservation, leaf
  struct.
- **trybuild**: 2 pass + 5 compile_fail with reviewed `.stderr`;
  renamed-crate fixture compiles via real cargo (`--offline`).
- 15/15 `amari-rewrite` suites `--all-features`; 3/3 macros-crate suites.
- Catalog regenerated (28 crates, 107 edges, `a7d6a0b5`); WASM surface
  unchanged.
- Verifiers: publish-order (9 tiers / 28 crates), version-sync,
  workflow-crates, sharding; MSRV 1.89 check; clippy `-D warnings` under
  both CI invocations; rustdoc `-D warnings` on the macros crate;
  publish dry-run zero errors (toolchain 1.97.1).
