### PR TITLE
feat: add discoverable rewrite syntax macros (0.25 Cohort 1, Task 5)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "a7d6a0b5981f558315dc1f16871da1410f789b53a8a658ef2527623f14bd7bb6",
+  "content_hash": "b496634333b2a8a4359f7c045db8328c969540277b7e24850dfd17ad9b98fad2",
   "crates": [
     {
       "name": "amari",
@@ -382432,14 +382432,14 @@
         {
           "path": "amari_rewrite_macros::rule",
           "kind": "fn",
-          "signature": "pub fn rule (_input : TokenStream) -> TokenStream",
+          "signature": "pub fn rule (input : TokenStream) -> TokenStream",
           "source_path": "amari-rewrite-macros/src/lib.rs",
           "is_reexport": false,
           "source_module": "amari_rewrite_macros",
           "variants": [
             {
               "kind": "fn",
-              "signature": "pub fn rule (_input : TokenStream) -> TokenStream",
+              "signature": "pub fn rule (input : TokenStream) -> TokenStream",
               "source_path": "amari-rewrite-macros/src/lib.rs",
               "source_module": "amari_rewrite_macros",
               "is_reexport": false,
@@ -382451,14 +382451,14 @@
         {
           "path": "amari_rewrite_macros::term",
           "kind": "fn",
-          "signature": "pub fn term (_input : TokenStream) -> TokenStream",
+          "signature": "pub fn term (input : TokenStream) -> TokenStream",
           "source_path": "amari-rewrite-macros/src/lib.rs",
           "is_reexport": false,
           "source_module": "amari_rewrite_macros",
           "variants": [
             {
               "kind": "fn",
-              "signature": "pub fn term (_input : TokenStream) -> TokenStream",
+              "signature": "pub fn term (input : TokenStream) -> TokenStream",
               "source_path": "amari-rewrite-macros/src/lib.rs",
               "source_module": "amari_rewrite_macros",
               "is_reexport": false,
@@ -382491,14 +382491,14 @@
           "name": "rule",
           "kind": "proc_macro",
           "source_path": "amari-rewrite-macros/src/lib.rs",
-          "signature": "pub fn rule (_input : TokenStream) -> TokenStream"
+          "signature": "pub fn rule (input : TokenStream) -> TokenStream"
         },
         {
           "path": "amari_rewrite_macros::term",
           "name": "term",
           "kind": "proc_macro",
           "source_path": "amari-rewrite-macros/src/lib.rs",
-          "signature": "pub fn term (_input : TokenStream) -> TokenStream"
+          "signature": "pub fn term (input : TokenStream) -> TokenStream"
         }
       ],
       "cfg_gates": [

--- a/amari-discovery/catalog/semantic/core.toml
+++ b/amari-discovery/catalog/semantic/core.toml
@@ -183,6 +183,34 @@ stability = "stable"
 cost = "moderate"
 
 [[capabilities]]
+id = "amari:amari-rewrite:macros:term-rule-constructors"
+name = "Checked rewrite term and rule syntax"
+description = "Build TRS terms and rules with term!/rule! macros that expand to checked constructors."
+aliases = ["term macro", "rule macro", "rewrite syntax"]
+concepts = ["term rewriting system", "procedural macros", "syntax"]
+crate_refs = ["amari-rewrite"]
+feature_refs = ["amari-rewrite:macros"]
+symbol_refs = ["amari_rewrite_macros::term", "amari_rewrite_macros::rule"]
+example_refs = []
+probe_refs = []
+stability = "experimental"
+cost = "low"
+
+[[capabilities]]
+id = "amari:amari-rewrite:macros:derive-rewritable"
+name = "Derive Rewritable for expression trees"
+description = "Derive child traversal and checked replacement for structs and enums with explicit child fields."
+aliases = ["rewritable derive", "rewritable macro"]
+concepts = ["term rewriting system", "procedural macros", "abstract syntax tree"]
+crate_refs = ["amari-rewrite"]
+feature_refs = ["amari-rewrite:macros"]
+symbol_refs = ["amari_rewrite_macros::derive_rewritable"]
+example_refs = []
+probe_refs = []
+stability = "experimental"
+cost = "low"
+
+[[capabilities]]
 id = "amari:amari-rewrite:inverse:predecessors"
 name = "Bounded predecessor search"
 description = "Enumerate deterministic inverse-rewrite predecessors under explicit depth, frontier, node, and byte limits."
@@ -239,3 +267,13 @@ kind = "supports"
 from = "amari:amari-rewrite:synthesis:infer-rule"
 to = "amari:amari-rewrite:trs:normalization"
 kind = "produces_input_for"
+
+[[relations]]
+from = "amari:amari-rewrite:macros:term-rule-constructors"
+to = "amari:amari-rewrite:trs:normalization"
+kind = "supports"
+
+[[relations]]
+from = "amari:amari-rewrite:macros:derive-rewritable"
+to = "amari:amari-rewrite:macros:term-rule-constructors"
+kind = "composes_with"

--- a/amari-discovery/tests/rewrite_discovery_macros.rs
+++ b/amari-discovery/tests/rewrite_discovery_macros.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Discovery surfacing for the rewrite syntax macros (0.25 Cohort 1,
+//! Task 5): semantic capability records are searchable, detailed, and
+//! graph-connected with correct feature refs; the structural catalog
+//! lists the macro package exactly once and never indexes
+//! amari-discovery itself.
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn discover_json(args: &[&str]) -> Value {
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn result_ids(value: &Value) -> Vec<String> {
+    value["data"]["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn search_finds_term_rule_macro_capability() {
+    let value = discover_json(&["discover", "search", "term macro", "--json"]);
+    let ids = result_ids(&value);
+    assert!(
+        ids.contains(&"amari:amari-rewrite:macros:term-rule-constructors".to_string()),
+        "term macro search should find the syntax capability: {ids:?}"
+    );
+}
+
+#[test]
+fn search_finds_derive_capability_by_alias() {
+    let value = discover_json(&["discover", "search", "rewritable derive", "--json"]);
+    let ids = result_ids(&value);
+    assert!(
+        ids.contains(&"amari:amari-rewrite:macros:derive-rewritable".to_string()),
+        "alias search should find the derive capability: {ids:?}"
+    );
+}
+
+#[test]
+fn detail_shows_macro_feature_refs() {
+    let value = discover_json(&[
+        "discover",
+        "detail",
+        "amari:amari-rewrite:macros:term-rule-constructors",
+        "--json",
+    ]);
+    let features = value["data"]["feature_refs"].as_array().unwrap();
+    assert!(
+        features.iter().any(|f| f == "amari-rewrite:macros"),
+        "detail must reference the macros feature: {features:?}"
+    );
+}
+
+#[test]
+fn graph_connects_macro_capability_to_crate() {
+    let value = discover_json(&[
+        "discover",
+        "graph",
+        "amari:amari-rewrite:macros:term-rule-constructors",
+        "--json",
+    ]);
+    let relations = value["data"]["relations"].as_array().unwrap();
+    assert!(
+        relations
+            .iter()
+            .any(|relation| { relation["to"] == "amari:amari-rewrite:trs:normalization" }),
+        "graph should relate the macros capability to TRS normalization: \
+         {relations:?}"
+    );
+}
+
+#[test]
+fn structural_catalog_lists_macro_package_exactly_once() {
+    let raw = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/catalog/generated.json"
+    ))
+    .unwrap();
+    let catalog: Value = serde_json::from_str(&raw).unwrap();
+    let crates = catalog["crates"].as_array().unwrap();
+    let macro_packages = crates
+        .iter()
+        .filter(|c| c["name"] == "amari-rewrite-macros")
+        .count();
+    assert_eq!(macro_packages, 1, "macro package must appear exactly once");
+    assert!(
+        crates.iter().all(|c| c["name"] != "amari-discovery"),
+        "amari-discovery must never index itself"
+    );
+}

--- a/amari-rewrite-macros/src/lib.rs
+++ b/amari-rewrite-macros/src/lib.rs
@@ -19,7 +19,9 @@
 
 use proc_macro::TokenStream;
 
+mod paths;
 mod rewritable_derive;
+mod syntax;
 
 fn not_yet(implemented_in: &str) -> TokenStream {
     let message = format!(
@@ -49,19 +51,24 @@ pub fn derive_rewritable(input: TokenStream) -> TokenStream {
 
 /// Checked `trs::Term` construction: `term!(add(zero, X))`.
 ///
-/// Identifier and string symbol spellings are equivalent. Expansion is to
-/// checked constructors; malformed terms are compile errors.
+/// Lowercase-leading identifiers and string literals are symbols
+/// (`term!(f)` == `term!("f")`); uppercase-leading identifiers are
+/// variables. A bare symbol (or empty parentheses) is a constant;
+/// variables never take arguments. Malformed terms are compile errors.
 #[proc_macro]
-pub fn term(_input: TokenStream) -> TokenStream {
-    not_yet("Task 5")
+pub fn term(input: TokenStream) -> TokenStream {
+    syntax::expand_term(input.into()).into()
 }
 
 /// Checked `trs::Rule` construction: `rule!(add(zero, X) => X)`.
 ///
-/// Resolves the fully qualified TRS rule, not the ARS `Rule` type.
+/// Expands to fully qualified `amari_rewrite::trs::Rule::new` — checked
+/// construction returning `RewriteResult<trs::Rule>` (right-hand-side
+/// variables must occur on the left), never the ARS `Rule` type and
+/// never unchecked construction.
 #[proc_macro]
-pub fn rule(_input: TokenStream) -> TokenStream {
-    not_yet("Task 5")
+pub fn rule(input: TokenStream) -> TokenStream {
+    syntax::expand_rule(input.into()).into()
 }
 
 /// Checked relational construction: `relation!(add(zero, X) <=> X)`.

--- a/amari-rewrite-macros/src/paths.rs
+++ b/amari-rewrite-macros/src/paths.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared resolution of the `amari-rewrite` crate path for generated
+//! code. `Itself` (expansion inside amari-rewrite's own targets) still
+//! uses `::amari_rewrite`, valid through
+//! `extern crate self as amari_rewrite` plus the implicit extern in
+//! integration/doc targets.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+
+pub fn rewrite_path() -> TokenStream {
+    let found = proc_macro_crate::crate_name("amari-rewrite");
+    match found {
+        Ok(proc_macro_crate::FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!(::#ident)
+        }
+        _ => quote!(::amari_rewrite),
+    }
+}

--- a/amari-rewrite-macros/src/rewritable_derive.rs
+++ b/amari-rewrite-macros/src/rewritable_derive.rs
@@ -15,6 +15,8 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+
+use crate::paths::rewrite_path;
 use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Error, Fields, Ident, Index, Member, Type};
 
@@ -163,21 +165,6 @@ fn reject_collection(ty: &Type) -> Result<(), Error> {
         ));
     }
     Ok(())
-}
-
-/// Resolve `amari-rewrite` for hygienic generated paths. `Itself`
-/// (expansion inside amari-rewrite's own targets) still uses
-/// `::amari_rewrite`, valid through `extern crate self as amari_rewrite`
-/// plus the implicit extern in integration/doc targets.
-fn rewrite_path() -> TokenStream {
-    let found = proc_macro_crate::crate_name("amari-rewrite");
-    match found {
-        Ok(proc_macro_crate::FoundCrate::Name(name)) => {
-            let ident = Ident::new(&name, proc_macro2::Span::call_site());
-            quote!(::#ident)
-        }
-        _ => quote!(::amari_rewrite),
-    }
 }
 
 fn generate(input: &DeriveInput, constructors: &[Constructor]) -> Result<TokenStream, Error> {

--- a/amari-rewrite-macros/src/syntax.rs
+++ b/amari-rewrite-macros/src/syntax.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Checked `term!` and `rule!` construction macros.
+//!
+//! Grammar:
+//!
+//! ```text
+//! term     := IDENT | STRING | IDENT "(" args ")" | STRING "(" args ")"
+//! rule     := term "=>" term
+//! ```
+//!
+//! Lowercase-leading identifiers and string literals are symbols
+//! (`term!(f)` == `term!("f")`); uppercase-leading identifiers are
+//! variables. A bare symbol (or one with empty parentheses) is a
+//! constant. Variables never take arguments.
+//!
+//! `rule!` expands to fully qualified
+//! `amari_rewrite::trs::Rule::new(lhs, rhs)` — checked construction
+//! (right-hand-side variables must occur on the left), never
+//! `new_unchecked`. All diagnostics use single-token spans so trybuild
+//! fixtures render identically across rustc versions.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{parenthesized, Error, Ident, LitStr, Token};
+
+use crate::paths::rewrite_path;
+
+enum TermSyntax {
+    Symbol { name: String, args: Vec<TermSyntax> },
+    Variable { name: String },
+}
+
+impl TermSyntax {
+    fn expand(&self, rewrite: &TokenStream) -> TokenStream {
+        match self {
+            TermSyntax::Variable { name } => {
+                quote!(#rewrite::trs::Term::var(#name))
+            }
+            TermSyntax::Symbol { name, args } if args.is_empty() => {
+                quote!(#rewrite::trs::Term::constant(#name))
+            }
+            TermSyntax::Symbol { name, args } => {
+                let expanded = args.iter().map(|arg| arg.expand(rewrite));
+                quote!(#rewrite::trs::Term::sym(#name, [#(#expanded),*]))
+            }
+        }
+    }
+}
+
+fn is_variable_name(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+impl Parse for TermSyntax {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        let (name, span) = if lookahead.peek(Ident) {
+            let ident: Ident = input.parse()?;
+            (ident.to_string(), ident.span())
+        } else if lookahead.peek(LitStr) {
+            let literal: LitStr = input.parse()?;
+            (literal.value(), literal.span())
+        } else {
+            return Err(lookahead.error());
+        };
+
+        if !input.peek(syn::token::Paren) {
+            return Ok(if is_variable_name(&name) {
+                TermSyntax::Variable { name }
+            } else {
+                TermSyntax::Symbol {
+                    name,
+                    args: Vec::new(),
+                }
+            });
+        }
+
+        if is_variable_name(&name) {
+            return Err(Error::new(span, "variables cannot have arguments"));
+        }
+        let content;
+        parenthesized!(content in input);
+        let args = content
+            .parse_terminated(TermSyntax::parse, Token![,])?
+            .into_iter()
+            .collect();
+        Ok(TermSyntax::Symbol { name, args })
+    }
+}
+
+struct RuleSyntax {
+    lhs: TermSyntax,
+    rhs: TermSyntax,
+}
+
+impl Parse for RuleSyntax {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lhs: TermSyntax = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let rhs: TermSyntax = input.parse()?;
+        if !input.is_empty() {
+            return Err(Error::new(
+                input.span(),
+                "unexpected tokens after rule right-hand side",
+            ));
+        }
+        Ok(RuleSyntax { lhs, rhs })
+    }
+}
+
+pub fn expand_term(input: TokenStream) -> TokenStream {
+    let parsed = syn::parse2::<TermSyntax>(input);
+    match parsed {
+        Ok(term) => {
+            let rewrite = rewrite_path();
+            term.expand(&rewrite)
+        }
+        Err(error) => error.into_compile_error(),
+    }
+}
+
+pub fn expand_rule(input: TokenStream) -> TokenStream {
+    let parsed = syn::parse2::<RuleSyntax>(input);
+    match parsed {
+        Ok(rule) => {
+            let rewrite = rewrite_path();
+            let lhs = rule.lhs.expand(&rewrite);
+            let rhs = rule.rhs.expand(&rewrite);
+            quote! {{
+                let __rewritable_lhs = #lhs;
+                let __rewritable_rhs = #rhs;
+                #rewrite::trs::Rule::new(__rewritable_lhs, __rewritable_rhs)
+            }}
+        }
+        Err(error) => error.into_compile_error(),
+    }
+}

--- a/amari-rewrite-macros/tests/renamed/src/main.rs
+++ b/amari-rewrite-macros/tests/renamed/src/main.rs
@@ -18,4 +18,10 @@ fn main() {
         rewrite_lib::Rewritable::child(&one, 0),
         Some(&Expr::Zero)
     );
+
+    // term!/rule! must resolve through the renamed crate as well.
+    let lhs = amari_rewrite_macros::term!(add(zero, X));
+    let built = amari_rewrite_macros::rule!(add(zero, X) => X).unwrap();
+    assert_eq!(built.lhs(), &lhs);
+    assert_eq!(built.rhs(), &amari_rewrite_macros::term!(X));
 }

--- a/amari-rewrite-macros/tests/ui.rs
+++ b/amari-rewrite-macros/tests/ui.rs
@@ -8,11 +8,16 @@ fn rewritable_ui() {
     let cases = trybuild::TestCases::new();
     cases.pass("tests/ui/pass_enum.rs");
     cases.pass("tests/ui/pass_struct_children.rs");
+    cases.pass("tests/ui/pass_term_rule.rs");
     cases.compile_fail("tests/ui/fail_union.rs");
     cases.compile_fail("tests/ui/fail_generic.rs");
     cases.compile_fail("tests/ui/fail_duplicate_child.rs");
     cases.compile_fail("tests/ui/fail_unknown_attribute.rs");
     cases.compile_fail("tests/ui/fail_collection_child.rs");
+    cases.compile_fail("tests/ui/fail_term_variable_arguments.rs");
+    cases.compile_fail("tests/ui/fail_term_literal.rs");
+    cases.compile_fail("tests/ui/fail_rule_arrow.rs");
+    cases.compile_fail("tests/ui/fail_rule_trailing.rs");
 }
 
 /// Renamed-crate support: the fixture under `tests/renamed` depends on

--- a/amari-rewrite-macros/tests/ui/fail_rule_arrow.rs
+++ b/amari-rewrite-macros/tests/ui/fail_rule_arrow.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::rule;
+
+fn main() {
+    let _ = rule!(f(X) -> g(X));
+}

--- a/amari-rewrite-macros/tests/ui/fail_rule_arrow.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_rule_arrow.stderr
@@ -1,0 +1,5 @@
+error: expected `=>`
+ --> tests/ui/fail_rule_arrow.rs:6:24
+  |
+6 |     let _ = rule!(f(X) -> g(X));
+  |                        ^

--- a/amari-rewrite-macros/tests/ui/fail_rule_trailing.rs
+++ b/amari-rewrite-macros/tests/ui/fail_rule_trailing.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::rule;
+
+fn main() {
+    let _ = rule!(f(X) => g(X) extra);
+}

--- a/amari-rewrite-macros/tests/ui/fail_rule_trailing.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_rule_trailing.stderr
@@ -1,0 +1,5 @@
+error: unexpected tokens after rule right-hand side
+ --> tests/ui/fail_rule_trailing.rs:6:32
+  |
+6 |     let _ = rule!(f(X) => g(X) extra);
+  |                                ^^^^^

--- a/amari-rewrite-macros/tests/ui/fail_term_literal.rs
+++ b/amari-rewrite-macros/tests/ui/fail_term_literal.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::term;
+
+fn main() {
+    let _ = term!(42);
+}

--- a/amari-rewrite-macros/tests/ui/fail_term_literal.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_term_literal.stderr
@@ -1,0 +1,5 @@
+error: expected identifier or string literal
+ --> tests/ui/fail_term_literal.rs:6:19
+  |
+6 |     let _ = term!(42);
+  |                   ^^

--- a/amari-rewrite-macros/tests/ui/fail_term_variable_arguments.rs
+++ b/amari-rewrite-macros/tests/ui/fail_term_variable_arguments.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_rewrite_macros::term;
+
+fn main() {
+    let _ = term!(X(zero));
+}

--- a/amari-rewrite-macros/tests/ui/fail_term_variable_arguments.stderr
+++ b/amari-rewrite-macros/tests/ui/fail_term_variable_arguments.stderr
@@ -1,0 +1,5 @@
+error: variables cannot have arguments
+ --> tests/ui/fail_term_variable_arguments.rs:6:19
+  |
+6 |     let _ = term!(X(zero));
+  |                   ^

--- a/amari-rewrite-macros/tests/ui/pass_term_rule.rs
+++ b/amari-rewrite-macros/tests/ui/pass_term_rule.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! term!/rule! in the external-crate resolution path.
+
+use amari_rewrite_macros::{rule, term};
+
+fn main() {
+    let lhs = term!(add(zero, X));
+    let built = rule!(add(zero, X) => X).unwrap();
+    assert_eq!(built.lhs(), &lhs);
+    assert_eq!(built.rhs(), &term!(X));
+    assert!(rule!(f(X) => g(Y)).is_err());
+}

--- a/amari-rewrite/tests/macros_term_rule.rs
+++ b/amari-rewrite/tests/macros_term_rule.rs
@@ -1,0 +1,71 @@
+//! Checked `term!`/`rule!` macro behavior (0.25 Cohort 1, Task 5).
+//!
+//! Grammar contract: lowercase-leading identifiers and string literals
+//! are symbols (`term!(f)` == `term!("f")`); uppercase-leading
+//! identifiers are variables; applications parenthesize arguments.
+//! `rule!(lhs => rhs)` expands to fully qualified
+//! `amari_rewrite::trs::Rule::new` — checked construction, never
+//! unchecked. Compile-time grammar rejections live in the trybuild
+//! fixtures under `amari-rewrite-macros/tests/ui/`.
+
+#![cfg(feature = "macros")]
+
+use amari_rewrite::trs::{Rule, Term};
+use amari_rewrite::{rule, term};
+
+#[test]
+fn constants_and_symbols() {
+    assert_eq!(term!(zero), Term::constant("zero"));
+    assert_eq!(term!("zero"), Term::constant("zero"));
+    // Identifier and string spellings are equivalent.
+    assert_eq!(term!(f), term!("f"));
+    // A bare parenthesized symbol is the same constant.
+    assert_eq!(term!(f()), term!(f));
+}
+
+#[test]
+fn variables_are_uppercase_identifiers() {
+    assert_eq!(term!(X), Term::var("X"));
+    assert_eq!(term!(Big), Term::var("Big"));
+    assert_ne!(term!(x), Term::var("x")); // lowercase x is a symbol
+}
+
+#[test]
+fn nested_applications() {
+    let expected = Term::sym("add", vec![Term::constant("zero"), Term::var("X")]);
+    assert_eq!(term!(add(zero, X)), expected);
+
+    let nested = term!(f(g(X), "h", zero()));
+    let expected = Term::sym(
+        "f",
+        vec![
+            Term::sym("g", vec![Term::var("X")]),
+            Term::constant("h"),
+            Term::constant("zero"),
+        ],
+    );
+    assert_eq!(nested, expected);
+}
+
+#[test]
+fn rule_constructs_checked_trs_rule() {
+    let built = rule!(add(zero, X) => X).unwrap();
+    assert_eq!(built.lhs(), &term!(add(zero, X)));
+    assert_eq!(built.rhs(), &term!(X));
+}
+
+#[test]
+fn rule_rhs_variables_are_checked() {
+    // Y never occurs on the left: checked construction must refuse.
+    assert!(rule!(f(X) => g(Y)).is_err());
+    assert!(rule!(f(X) => g(X)).is_ok());
+}
+
+#[test]
+fn rule_macro_resolves_trs_rule_not_ars_rule() {
+    // Both Rule types in scope; the macro output is the TRS rule.
+    use amari_rewrite::ars::Rule as _;
+    fn assert_trs_rule(_: &Rule) {}
+    let built = rule!(f(X) => X).unwrap();
+    assert_trs_rule(&built);
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -77,6 +77,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_surreal",
         "probe_tropical",
         "probe_worker_protocol",
+        "rewrite_discovery_macros",
         "shell",
         "shell_agent_contract",
     ),


### PR DESCRIPTION
# 0.25 Cohort 1, Task 5: checked `term!`/`rule!` + discover macros

Final Cohort 1 task, per the
[plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md).
`relation!` stays scaffolded (Cohort 2).

## Macro grammar & expansion

- `term!(add(zero, X))` — lowercase-leading identifiers and string
  literals are symbols (`term!(f)` == `term!("f")`); uppercase-leading
  identifiers are variables; variables never take arguments; empty
  parentheses are constants.
- `rule!(lhs => rhs)` expands to fully qualified
  `::amari_rewrite::trs::Rule::new` — checked `RewriteResult`
  construction (RHS variables must occur on the left), **never**
  `new_unchecked`, never the ARS `Rule` type.
- All diagnostics use **single-token spans** (Task 4's toolchain
  lesson); verified identical under rustc 1.89.0 and 1.97.1.
- `proc-macro-crate` path resolution extracted to shared `src/paths.rs`
  (derive module refactored onto it — no behavior change).

## Discovery surfacing

- Semantic catalog: capabilities for the term/rule constructors and
  the derive (`feature_refs: amari-rewrite:macros`, declaration-site
  symbol refs, `experimental` stability), plus two `[[relations]]`
  records linking into TRS normalization.
- New `rewrite_discovery_macros.rs` (planner shard, registered —
  61 targets verified): CLI search/detail/graph tests + structural
  invariants (macro package indexed exactly once; no discovery
  self-indexing).

## Evidence

- **RED→GREEN** documented; 6/6 `macros_term_rule` runtime tests
  (nesting, string/ident equivalence, checked RHS variables, ARS/TRS
  `Rule` coexistence); 7/7 derive + 2/2 re-export suites still green.
- trybuild: 3 pass / 9 compile_fail with reviewed `.stderr`; renamed-
  crate fixture extended with `term!`/`rule!` (real cargo compile).
- 16/16 rewrite suites `--all-features`; 3/3 macros suites; discovery
  catalog shard 20 ok + planner shard 33 ok, zero failures (inspection
  shard untouched by this diff; CI runs it).
- Catalog regenerated (28 crates, 107 edges, `b4966343` — doc-text
  drift only); WASM surface unchanged; publish tiers dependency-safe;
  MSRV 1.89 check; clippy `-D warnings` both invocations; rustdoc
  `-D warnings`; fmt clean.

Cohort 1 closes here; Cohort 2 (constrained relations, backward
clauses — the inverse track) starts next.
