### PR TITLE
feat: define constrained relation authority (0.25 Cohort 2, Task 6)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "b496634333b2a8a4359f7c045db8328c969540277b7e24850dfd17ad9b98fad2",
+  "content_hash": "fcfd3cac25693b586dde8cfa9dc97843a56700e08f0f8dabfe5cfab3a833a606",
   "crates": [
     {
       "name": "amari",
@@ -373823,8 +373823,9 @@
           "kind": "normal",
           "version": "1.0",
           "optional": true,
-          "default_features": true,
+          "default_features": false,
           "features": [
+            "alloc",
             "derive"
           ]
         },
@@ -373854,6 +373855,14 @@
           "features": [
             "vendored"
           ]
+        },
+        {
+          "alias": "serde_json",
+          "package": "serde_json",
+          "kind": "development",
+          "version": "1",
+          "optional": false,
+          "default_features": true
         }
       ],
       "targets": [
@@ -374190,6 +374199,54 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "InvalidLimit",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "value",
+                      "ty": "usize"
+                    },
+                    {
+                      "name": "ceiling",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "RelationLimitExceeded",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "limit",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidDigest",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -374235,6 +374292,54 @@
                   },
                   {
                     "name": "InvalidRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidLimit",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "value",
+                          "ty": "usize"
+                        },
+                        {
+                          "name": "ceiling",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "RelationLimitExceeded",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "limit",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidDigest",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -374696,6 +374801,54 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "InvalidLimit",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "value",
+                      "ty": "usize"
+                    },
+                    {
+                      "name": "ceiling",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "RelationLimitExceeded",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "limit",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidDigest",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -374741,6 +374894,54 @@
                   },
                   {
                     "name": "InvalidRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidLimit",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "value",
+                          "ty": "usize"
+                        },
+                        {
+                          "name": "ceiling",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "RelationLimitExceeded",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "limit",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidDigest",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -375315,6 +375516,54 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "InvalidLimit",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "value",
+                      "ty": "usize"
+                    },
+                    {
+                      "name": "ceiling",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "RelationLimitExceeded",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "resource",
+                      "ty": "& 'static str"
+                    },
+                    {
+                      "name": "limit",
+                      "ty": "usize"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidDigest",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -375360,6 +375609,54 @@
                   },
                   {
                     "name": "InvalidRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidLimit",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "value",
+                          "ty": "usize"
+                        },
+                        {
+                          "name": "ceiling",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "RelationLimitExceeded",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "resource",
+                          "ty": "& 'static str"
+                        },
+                        {
+                          "name": "limit",
+                          "ty": "usize"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidDigest",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -376614,6 +376911,654 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::synthesis::inference",
               "declaration_ident": "infer_rules"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar",
+          "kind": "struct",
+          "signature": "pub struct LogicVar",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct LogicVar",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVar"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::index",
+          "kind": "method",
+          "signature": "pub fn index (& self) -> u32",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn index (& self) -> u32",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVar::index"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::new",
+          "kind": "method",
+          "signature": "pub fn new (scope : u32 , index : u32) -> Self",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (scope : u32 , index : u32) -> Self",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVar::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::scope",
+          "kind": "method",
+          "signature": "pub fn scope (& self) -> u32",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn scope (& self) -> u32",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVar::scope"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace",
+          "kind": "struct",
+          "signature": "pub struct LogicVarNamespace",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct LogicVarNamespace",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVarNamespace"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::allocated",
+          "kind": "method",
+          "signature": "pub fn allocated (& self) -> u32",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn allocated (& self) -> u32",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVarNamespace::allocated"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::fresh",
+          "kind": "method",
+          "signature": "pub fn fresh (& mut self) -> LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn fresh (& mut self) -> LogicVar",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVarNamespace::fresh"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::new",
+          "kind": "method",
+          "signature": "pub fn new (scope : u32) -> Self",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::variable",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (scope : u32) -> Self",
+              "source_path": "amari-rewrite/src/relation/variable.rs",
+              "source_module": "amari_rewrite::relation::variable",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::variable",
+              "declaration_ident": "LogicVarNamespace::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits",
+          "kind": "struct",
+          "signature": "pub struct RelationLimits",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RelationLimits",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_CONSTRAINTS",
+          "kind": "const",
+          "signature": "pub const MAX_CONSTRAINTS : usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_CONSTRAINTS : usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::MAX_CONSTRAINTS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_OPERATIONS",
+          "kind": "const",
+          "signature": "pub const MAX_OPERATIONS : usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_OPERATIONS : usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::MAX_OPERATIONS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_TERM_DEPTH",
+          "kind": "const",
+          "signature": "pub const MAX_TERM_DEPTH : usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TERM_DEPTH : usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::MAX_TERM_DEPTH"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_TERM_NODES",
+          "kind": "const",
+          "signature": "pub const MAX_TERM_NODES : usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TERM_NODES : usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::MAX_TERM_NODES"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_constraints",
+          "kind": "method",
+          "signature": "pub fn max_constraints (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_constraints (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::max_constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_operations",
+          "kind": "method",
+          "signature": "pub fn max_operations (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_operations (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::max_operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_term_depth",
+          "kind": "method",
+          "signature": "pub fn max_term_depth (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_term_depth (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::max_term_depth"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_term_nodes",
+          "kind": "method",
+          "signature": "pub fn max_term_nodes (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_term_nodes (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::max_term_nodes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::new",
+          "kind": "method",
+          "signature": "pub fn new (max_term_nodes : usize , max_term_depth : usize , max_constraints : usize , max_operations : usize ,) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (max_term_nodes : usize , max_term_depth : usize , max_constraints : usize , max_operations : usize ,) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationLimits::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources",
+          "kind": "struct",
+          "signature": "pub struct RelationResources",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RelationResources",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::constraints",
+          "kind": "method",
+          "signature": "pub fn constraints (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn constraints (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::new",
+          "kind": "method",
+          "signature": "pub fn new (limits : & RelationLimits) -> Self",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (limits : & RelationLimits) -> Self",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::operations",
+          "kind": "method",
+          "signature": "pub fn operations (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn operations (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_constraints",
+          "kind": "method",
+          "signature": "pub fn record_constraints (& mut self , additional : usize) -> RewriteResult < () >",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_constraints (& mut self , additional : usize) -> RewriteResult < () >",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::record_constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_operations",
+          "kind": "method",
+          "signature": "pub fn record_operations (& mut self , additional : usize) -> RewriteResult < () >",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_operations (& mut self , additional : usize) -> RewriteResult < () >",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::record_operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_term",
+          "kind": "method",
+          "signature": "pub fn record_term (& mut self , nodes : usize , depth : usize) -> RewriteResult < () >",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::limits",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_term (& mut self , nodes : usize , depth : usize) -> RewriteResult < () >",
+              "source_path": "amari-rewrite/src/relation/limits.rs",
+              "source_module": "amari_rewrite::relation::limits",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::limits",
+              "declaration_ident": "RelationResources::record_term"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest",
+          "kind": "struct",
+          "signature": "pub struct Sha256Digest",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct Sha256Digest",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::as_bytes",
+          "kind": "method",
+          "signature": "pub fn as_bytes (& self) -> & [u8 ; 32]",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn as_bytes (& self) -> & [u8 ; 32]",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::as_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::canonical_term",
+          "kind": "method",
+          "signature": "pub fn canonical_term (frame : & str , term : & Term) -> Self",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn canonical_term (frame : & str , term : & Term) -> Self",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::canonical_term"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::framed",
+          "kind": "method",
+          "signature": "pub fn framed (frame : & str , payload : & [u8]) -> Self",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn framed (frame : & str , payload : & [u8]) -> Self",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::framed"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::from_bytes",
+          "kind": "method",
+          "signature": "pub fn from_bytes (bytes : [u8 ; 32]) -> Self",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn from_bytes (bytes : [u8 ; 32]) -> Self",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::from_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::parse_hex",
+          "kind": "method",
+          "signature": "pub fn parse_hex (text : & str) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn parse_hex (text : & str) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::parse_hex"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::to_hex",
+          "kind": "method",
+          "signature": "pub fn to_hex (& self) -> String",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::digest",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn to_hex (& self) -> String",
+              "source_path": "amari-rewrite/src/relation/digest.rs",
+              "source_module": "amari_rewrite::relation::digest",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::digest",
+              "declaration_ident": "Sha256Digest::to_hex"
             }
           ]
         },
@@ -378483,6 +379428,96 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::LogicVarNamespace",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::RelationResources",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -378674,6 +379709,60 @@
             "kind": "local",
             "module": "amari_rewrite::ars",
             "ident": "Strategy"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -378934,6 +380023,78 @@
         },
         {
           "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::LogicVarNamespace",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::RelationResources",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -379201,6 +380362,24 @@
           "unsafe_trait": false,
           "negative": false,
           "is_derived": true
+        },
+        {
+          "trait_path": "Default",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Default"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
         },
         {
           "trait_path": "Default",
@@ -379504,6 +380683,96 @@
             "kind": "local",
             "module": "amari_rewrite::trs::rule",
             "ident": "Rule"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::LogicVarNamespace",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::RelationResources",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -379928,6 +381197,42 @@
         },
         {
           "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -380083,6 +381388,42 @@
             "kind": "local",
             "module": "amari_rewrite::trs::term",
             "ident": "Term"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Ord",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Ord"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Ord",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Ord"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380397,6 +381738,96 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::LogicVarNamespace",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationLimits"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::RelationResources",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::limits",
+            "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -380577,6 +382008,42 @@
         },
         {
           "trait_path": "PartialOrd",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialOrd"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialOrd",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialOrd"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialOrd",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -380718,6 +382185,60 @@
             "kind": "local",
             "module": "amari_rewrite::trs::term",
             "ident": "Term"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "fmt::Debug",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 6,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "fmt::Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "fmt::Display",
+          "impl_type_path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "fmt::Display"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::variable",
+            "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "fmt::Display",
+          "impl_type_path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "fmt::Display"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::digest",
+            "ident": "Sha256Digest"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381714,6 +383235,270 @@
           "surface_kind": "top_level"
         },
         {
+          "path": "amari_rewrite::relation",
+          "source_path": "amari-rewrite/src/relation/mod.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "module"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::index",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::new",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVar::scope",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::allocated",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::fresh",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::LogicVarNamespace::new",
+          "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_CONSTRAINTS",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_OPERATIONS",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_TERM_DEPTH",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::MAX_TERM_NODES",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_constraints",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_operations",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 9,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_term_depth",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 7,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::max_term_nodes",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationLimits::new",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::constraints",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::new",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::operations",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_constraints",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_operations",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RelationResources::record_term",
+          "source_path": "amari-rewrite/src/relation/limits.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::as_bytes",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::canonical_term",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::framed",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::from_bytes",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::parse_hex",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::Sha256Digest::to_hex",
+          "source_path": "amari-rewrite/src/relation/digest.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::rewritable",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -382309,6 +384094,7 @@
         "amari_rewrite::neural",
         "amari_rewrite::prelude",
         "amari_rewrite::prelude::anti_unify",
+        "amari_rewrite::relation",
         "amari_rewrite::rewritable",
         "amari_rewrite::smt",
         "amari_rewrite::synthesis",

--- a/amari-rewrite/Cargo.toml
+++ b/amari-rewrite/Cargo.toml
@@ -13,7 +13,10 @@ categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
 thiserror = { workspace = true }
-serde = { workspace = true, optional = true }
+# serde is declared directly (not workspace-inherited) so `serialize`
+# stays no_std-correct: the workspace serde enables std, which would
+# defeat no-default builds.
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 sha2 = { workspace = true }
 amari-network = { workspace = true, optional = true }
 amari-holographic = { workspace = true, optional = true }
@@ -31,3 +34,6 @@ smt = ["std", "dep:z3"]
 neural = ["std", "dep:candle-core", "dep:candle-nn"]
 network = ["std", "neural", "dep:amari-network"]
 holographic-guidance = ["std", "dep:amari-holographic"]
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/amari-rewrite/src/error.rs
+++ b/amari-rewrite/src/error.rs
@@ -19,6 +19,30 @@ pub enum RewriteError {
     /// A rewrite rule failed validation.
     #[error("invalid rule: {message}")]
     InvalidRule { message: String },
+    /// A relation limit was zero or exceeded its fixed ceiling.
+    #[error("invalid relation limit {resource}: {value} (ceiling {ceiling})")]
+    InvalidLimit {
+        /// The limit being set.
+        resource: &'static str,
+        /// The rejected value.
+        value: usize,
+        /// The fixed ceiling.
+        ceiling: usize,
+    },
+    /// A relation resource budget was exhausted.
+    #[error("relation resource exhausted: {resource} (limit {limit})")]
+    RelationLimitExceeded {
+        /// The exhausted resource.
+        resource: &'static str,
+        /// The configured limit.
+        limit: usize,
+    },
+    /// A SHA-256 digest failed validation.
+    #[error("invalid sha-256 digest: {message}")]
+    InvalidDigest {
+        /// Validation failure detail.
+        message: String,
+    },
 }
 
 /// Result type used throughout `amari-rewrite`.

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ars;
 pub mod error;
 pub mod inverse;
 pub mod prelude;
+pub mod relation;
 pub mod rewritable;
 pub mod synthesis;
 pub mod trs;

--- a/amari-rewrite/src/relation/digest.rs
+++ b/amari-rewrite/src/relation/digest.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Framed SHA-256 digests and alpha-canonical term serialization.
+//!
+//! All relation authority identity uses framed digests: the frame is a
+//! length-prefixed domain label, so identical payloads under different
+//! frames never collide. Canonical term serialization renumbers
+//! variables by first structural occurrence (preorder), so
+//! alpha-equivalent terms hash identically regardless of caller names.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use core::fmt;
+
+use sha2::{Digest, Sha256};
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::trs::Term;
+
+/// A validated SHA-256 digest.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct Sha256Digest([u8; 32]);
+
+impl Sha256Digest {
+    /// Wrap raw digest bytes.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the digest bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Framed digest: `SHA-256(u32le frame len || frame || payload)`.
+    pub fn framed(frame: &str, payload: &[u8]) -> Self {
+        let mut hasher = Sha256::new();
+        let frame_len = u32::try_from(frame.len()).unwrap_or(u32::MAX);
+        hasher.update(frame_len.to_le_bytes());
+        hasher.update(frame.as_bytes());
+        hasher.update(payload);
+        Self(hasher.finalize().into())
+    }
+
+    /// Canonical alpha-invariant digest of a term under `frame`.
+    ///
+    /// Variables are renumbered by first structural occurrence in
+    /// preorder; symbols and variables occupy disjoint tags; arity and
+    /// name lengths are explicit, so encodings are prefix-free.
+    pub fn canonical_term(frame: &str, term: &Term) -> Self {
+        let mut encoding = Vec::new();
+        let mut variables: Vec<String> = Vec::new();
+        encode_term(term, &mut variables, &mut encoding);
+        Self::framed(frame, &encoding)
+    }
+
+    /// Canonical lowercase hex rendering.
+    pub fn to_hex(&self) -> String {
+        let mut out = String::with_capacity(64);
+        for byte in self.0 {
+            out.push(char::from_digit((byte >> 4) as u32, 16).unwrap_or('0'));
+            out.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap_or('0'));
+        }
+        out
+    }
+
+    /// Parse a canonical lowercase hex digest (exactly 64 characters).
+    pub fn parse_hex(text: &str) -> RewriteResult<Self> {
+        let invalid = |message: &str| RewriteError::InvalidDigest {
+            message: String::from(message),
+        };
+        if text.len() != 64 {
+            return Err(invalid("expected exactly 64 hex characters"));
+        }
+        let bytes = text.as_bytes();
+        let mut digest = [0u8; 32];
+        for (index, pair) in bytes.chunks_exact(2).enumerate() {
+            let high =
+                hex_value(pair[0]).ok_or_else(|| invalid("non-hex or non-lowercase character"))?;
+            let low =
+                hex_value(pair[1]).ok_or_else(|| invalid("non-hex or non-lowercase character"))?;
+            digest[index] = (high << 4) | low;
+        }
+        Ok(Self(digest))
+    }
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Preorder canonical encoding with alpha-renaming: variables become
+/// indices by first occurrence; structure, arities, and symbol names
+/// are explicit.
+fn encode_term(term: &Term, variables: &mut Vec<String>, out: &mut Vec<u8>) {
+    match term {
+        Term::Var(variable) => {
+            let name = variable.to_string();
+            let index = variables
+                .iter()
+                .position(|known| *known == name)
+                .unwrap_or_else(|| {
+                    variables.push(name);
+                    variables.len() - 1
+                });
+            out.push(0x00);
+            push_u32(out, index as u32);
+        }
+        Term::Sym(symbol, args) => {
+            out.push(0x01);
+            let name = symbol.to_string();
+            push_u32(out, args.len() as u32);
+            push_u32(out, name.len() as u32);
+            out.extend_from_slice(name.as_bytes());
+            for arg in args {
+                encode_term(arg, variables, out);
+            }
+        }
+    }
+}
+
+fn push_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+impl fmt::Display for Sha256Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl fmt::Debug for Sha256Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Sha256Digest({self})")
+    }
+}

--- a/amari-rewrite/src/relation/limits.rs
+++ b/amari-rewrite/src/relation/limits.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Relation limits and resource accounting.
+//!
+//! Fixed ceilings are associated constants and cannot be raised by
+//! callers; [`RelationLimits::new`] only accepts tightened values.
+//! Limits are validated before allocation, recursion, or search, and
+//! [`RelationResources`] enforces them at runtime.
+
+use crate::error::{RewriteError, RewriteResult};
+
+/// Caller-tightenable limits for constrained relation evaluation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RelationLimits {
+    max_term_nodes: usize,
+    max_term_depth: usize,
+    max_constraints: usize,
+    max_operations: usize,
+}
+
+impl RelationLimits {
+    /// Hard ceiling for nodes per term (design resource authority).
+    pub const MAX_TERM_NODES: usize = 4_096;
+    /// Hard ceiling for term depth.
+    pub const MAX_TERM_DEPTH: usize = 64;
+    /// Hard ceiling for constraints per constraint set.
+    pub const MAX_CONSTRAINTS: usize = 4_096;
+    /// Hard ceiling for accounted operations per query.
+    pub const MAX_OPERATIONS: usize = 1_000_000;
+
+    /// Construct tightened limits. Zero or above-ceiling values are
+    /// rejected: limits exist to bound work, not to disable or expand
+    /// the authority.
+    pub fn new(
+        max_term_nodes: usize,
+        max_term_depth: usize,
+        max_constraints: usize,
+        max_operations: usize,
+    ) -> RewriteResult<Self> {
+        let candidate = Self {
+            max_term_nodes,
+            max_term_depth,
+            max_constraints,
+            max_operations,
+        };
+        candidate.check("term nodes", max_term_nodes, Self::MAX_TERM_NODES)?;
+        candidate.check("term depth", max_term_depth, Self::MAX_TERM_DEPTH)?;
+        candidate.check("constraints", max_constraints, Self::MAX_CONSTRAINTS)?;
+        candidate.check("operations", max_operations, Self::MAX_OPERATIONS)?;
+        Ok(candidate)
+    }
+
+    fn check(&self, resource: &'static str, value: usize, ceiling: usize) -> RewriteResult<()> {
+        let _ = self;
+        if value == 0 || value > ceiling {
+            return Err(RewriteError::InvalidLimit {
+                resource,
+                value,
+                ceiling,
+            });
+        }
+        Ok(())
+    }
+
+    /// Maximum nodes per term.
+    pub fn max_term_nodes(&self) -> usize {
+        self.max_term_nodes
+    }
+
+    /// Maximum term depth.
+    pub fn max_term_depth(&self) -> usize {
+        self.max_term_depth
+    }
+
+    /// Maximum constraints per constraint set.
+    pub fn max_constraints(&self) -> usize {
+        self.max_constraints
+    }
+
+    /// Maximum accounted operations per query.
+    pub fn max_operations(&self) -> usize {
+        self.max_operations
+    }
+}
+
+impl Default for RelationLimits {
+    /// The default profile is the fixed ceiling profile.
+    fn default() -> Self {
+        Self {
+            max_term_nodes: Self::MAX_TERM_NODES,
+            max_term_depth: Self::MAX_TERM_DEPTH,
+            max_constraints: Self::MAX_CONSTRAINTS,
+            max_operations: Self::MAX_OPERATIONS,
+        }
+    }
+}
+
+/// Running resource budget for one relation query.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RelationResources {
+    max_term_nodes: usize,
+    max_term_depth: usize,
+    max_constraints: usize,
+    max_operations: usize,
+    constraints: usize,
+    operations: usize,
+}
+
+impl RelationResources {
+    /// Open a budget under the given limits.
+    pub fn new(limits: &RelationLimits) -> Self {
+        Self {
+            max_term_nodes: limits.max_term_nodes,
+            max_term_depth: limits.max_term_depth,
+            max_constraints: limits.max_constraints,
+            max_operations: limits.max_operations,
+            constraints: 0,
+            operations: 0,
+        }
+    }
+
+    /// Account one term of `nodes` nodes and `depth` depth. Per-term
+    /// bounds are per value, not cumulative.
+    pub fn record_term(&mut self, nodes: usize, depth: usize) -> RewriteResult<()> {
+        if nodes > self.max_term_nodes {
+            return Err(RewriteError::RelationLimitExceeded {
+                resource: "term nodes",
+                limit: self.max_term_nodes,
+            });
+        }
+        if depth > self.max_term_depth {
+            return Err(RewriteError::RelationLimitExceeded {
+                resource: "term depth",
+                limit: self.max_term_depth,
+            });
+        }
+        Ok(())
+    }
+
+    /// Account additional constraints (cumulative).
+    pub fn record_constraints(&mut self, additional: usize) -> RewriteResult<()> {
+        let next = self.constraints.saturating_add(additional);
+        if next > self.max_constraints {
+            return Err(RewriteError::RelationLimitExceeded {
+                resource: "constraints",
+                limit: self.max_constraints,
+            });
+        }
+        self.constraints = next;
+        Ok(())
+    }
+
+    /// Account additional operations (cumulative).
+    pub fn record_operations(&mut self, additional: usize) -> RewriteResult<()> {
+        let next = self.operations.saturating_add(additional);
+        if next > self.max_operations {
+            return Err(RewriteError::RelationLimitExceeded {
+                resource: "operations",
+                limit: self.max_operations,
+            });
+        }
+        self.operations = next;
+        Ok(())
+    }
+
+    /// Constraints accounted so far.
+    pub fn constraints(&self) -> usize {
+        self.constraints
+    }
+
+    /// Operations accounted so far.
+    pub fn operations(&self) -> usize {
+        self.operations
+    }
+}

--- a/amari-rewrite/src/relation/mod.rs
+++ b/amari-rewrite/src/relation/mod.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Constrained rewrite-relation foundations (0.25 Cohort 2).
+//!
+//! This module holds the authority types every backward-relation
+//! feature builds on: deterministic query-scoped [`LogicVarNamespace`]
+//! allocation of [`LogicVar`]s, caller-tightenable [`RelationLimits`]
+//! against fixed ceilings, runtime [`RelationResources`] accounting,
+//! and framed [`Sha256Digest`] canonical identity. Unification,
+//! constraint normalization, and backward clauses build on these in
+//! later tasks.
+
+mod digest;
+mod limits;
+mod variable;
+
+pub use digest::Sha256Digest;
+pub use limits::{RelationLimits, RelationResources};
+pub use variable::{LogicVar, LogicVarNamespace};

--- a/amari-rewrite/src/relation/variable.rs
+++ b/amari-rewrite/src/relation/variable.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Logic variables and deterministic freshening namespaces.
+//!
+//! [`LogicVar`] is distinct from display-level [`crate::trs::Variable`]
+//! names: it carries a query scope and an index so backward-relation
+//! machinery never collides with user-named variables. Every backward
+//! application allocates from a deterministic query-scoped namespace;
+//! canonical serialization (see [`crate::relation::Sha256Digest`])
+//! renumbers by first structural occurrence, so caller names and
+//! traversal accidents cannot change hashes.
+
+use core::fmt;
+
+/// A freshened logic variable: `(scope, index)` within a query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct LogicVar {
+    scope: u32,
+    index: u32,
+}
+
+impl LogicVar {
+    /// Construct a logic variable directly ( deserialization and
+    /// fixed-point testing; freshening goes through
+    /// [`LogicVarNamespace`]).
+    pub fn new(scope: u32, index: u32) -> Self {
+        Self { scope, index }
+    }
+
+    /// The query scope this variable was freshened in.
+    pub fn scope(&self) -> u32 {
+        self.scope
+    }
+
+    /// The allocation index within the scope.
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+}
+
+impl fmt::Display for LogicVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "?{}.{}", self.scope, self.index)
+    }
+}
+
+/// Deterministic query-scoped logic-variable allocator.
+///
+/// Two namespaces constructed with the same scope yield identical
+/// sequences; different scopes yield disjoint identities.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct LogicVarNamespace {
+    scope: u32,
+    next: u32,
+}
+
+impl LogicVarNamespace {
+    /// Open a namespace for one query scope.
+    pub fn new(scope: u32) -> Self {
+        Self { scope, next: 0 }
+    }
+
+    /// Allocate the next logic variable in this scope.
+    pub fn fresh(&mut self) -> LogicVar {
+        let var = LogicVar::new(self.scope, self.next);
+        self.next = self.next.saturating_add(1);
+        var
+    }
+
+    /// Number of variables allocated so far.
+    pub fn allocated(&self) -> u32 {
+        self.next
+    }
+}

--- a/amari-rewrite/tests/relation_contract.rs
+++ b/amari-rewrite/tests/relation_contract.rs
@@ -1,0 +1,199 @@
+//! Relation authority contract tests (0.25 Cohort 2, Task 6).
+//!
+//! Covers the foundations every later relation module depends on:
+//! caller-tightenable limits against fixed ceilings, deterministic
+//! query-scoped logic-variable namespaces, alpha-canonical term
+//! digests with framed SHA-256, and resource accounting. Runs under
+//! default, no-default, and serialize feature combinations.
+
+use amari_rewrite::relation::{LogicVarNamespace, RelationLimits, RelationResources, Sha256Digest};
+use amari_rewrite::trs::Term;
+use amari_rewrite::RewriteError;
+
+#[test]
+fn zero_limits_are_rejected() {
+    for args in [
+        (0, 64, 4_096, 1_000_000),
+        (4_096, 0, 4_096, 1_000_000),
+        (4_096, 64, 0, 1_000_000),
+        (4_096, 64, 4_096, 0),
+    ] {
+        let result = RelationLimits::new(args.0, args.1, args.2, args.3);
+        assert!(
+            matches!(result, Err(RewriteError::InvalidLimit { .. })),
+            "zero limit must be rejected: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn oversized_limits_are_rejected_against_fixed_ceilings() {
+    let over = RelationLimits::new(RelationLimits::MAX_TERM_NODES + 1, 64, 4_096, 1_000_000);
+    assert!(matches!(over, Err(RewriteError::InvalidLimit { .. })));
+    let over_depth =
+        RelationLimits::new(4_096, RelationLimits::MAX_TERM_DEPTH + 1, 4_096, 1_000_000);
+    assert!(matches!(over_depth, Err(RewriteError::InvalidLimit { .. })));
+}
+
+#[test]
+fn tightened_limits_are_accepted_and_clamped() {
+    let limits = RelationLimits::new(16, 4, 8, 100).unwrap();
+    assert_eq!(limits.max_term_nodes(), 16);
+    assert_eq!(limits.max_term_depth(), 4);
+    assert_eq!(limits.max_constraints(), 8);
+    assert_eq!(limits.max_operations(), 100);
+
+    let ceilings = RelationLimits::default();
+    assert_eq!(ceilings.max_term_nodes(), RelationLimits::MAX_TERM_NODES);
+    assert_eq!(ceilings.max_term_depth(), RelationLimits::MAX_TERM_DEPTH);
+    assert_eq!(ceilings.max_constraints(), RelationLimits::MAX_CONSTRAINTS);
+    assert_eq!(ceilings.max_operations(), RelationLimits::MAX_OPERATIONS);
+}
+
+#[test]
+fn namespaces_are_deterministic_and_query_scoped() {
+    let mut first = LogicVarNamespace::new(7);
+    let mut second = LogicVarNamespace::new(7);
+    let mut other = LogicVarNamespace::new(8);
+
+    let a: Vec<_> = (0..4).map(|_| first.fresh()).collect();
+    let b: Vec<_> = (0..4).map(|_| second.fresh()).collect();
+    let c: Vec<_> = (0..4).map(|_| other.fresh()).collect();
+
+    // Same query scope: identical sequences.
+    assert_eq!(a, b);
+    // Different scopes: disjoint identities.
+    assert!(a.iter().all(|v| !c.contains(v)));
+    // Distinct indices within a namespace.
+    for (index, var) in a.iter().enumerate() {
+        assert_eq!(a.iter().filter(|v| *v == var).count(), 1);
+        let _ = index;
+    }
+}
+
+#[test]
+fn canonical_digests_are_alpha_invariant() {
+    let left = Term::sym(
+        "f",
+        vec![Term::var("X"), Term::sym("g", vec![Term::var("X")])],
+    );
+    let right = Term::sym(
+        "f",
+        vec![Term::var("Y"), Term::sym("g", vec![Term::var("Y")])],
+    );
+    assert_eq!(
+        Sha256Digest::canonical_term("amari.relation.term/v1", &left),
+        Sha256Digest::canonical_term("amari.relation.term/v1", &right),
+        "alpha-equivalent terms must hash identically"
+    );
+
+    let distinct = Term::sym("f", vec![Term::var("X"), Term::var("Y")]);
+    let repeated = Term::sym("f", vec![Term::var("X"), Term::var("X")]);
+    assert_ne!(
+        Sha256Digest::canonical_term("amari.relation.term/v1", &distinct),
+        Sha256Digest::canonical_term("amari.relation.term/v1", &repeated),
+        "distinct structure must hash distinctly"
+    );
+    // Symbols and variables never collide.
+    assert_ne!(
+        Sha256Digest::canonical_term("amari.relation.term/v1", &Term::var("a")),
+        Sha256Digest::canonical_term("amari.relation.term/v1", &Term::constant("a")),
+    );
+}
+
+#[test]
+fn framed_digests_are_domain_separated() {
+    let payload = b"same bytes";
+    let a = Sha256Digest::framed("amari.relation.term/v1", payload);
+    let b = Sha256Digest::framed("amari.relation.rule/v1", payload);
+    assert_ne!(a, b, "frames must separate identical payloads");
+    // Deterministic.
+    assert_eq!(a, Sha256Digest::framed("amari.relation.term/v1", payload));
+}
+
+#[test]
+fn digest_hex_roundtrips_and_validates() {
+    let digest = Sha256Digest::framed("amari.relation.term/v1", b"payload");
+    let hex = digest.to_hex();
+    assert_eq!(hex.len(), 64);
+    let parsed = Sha256Digest::parse_hex(&hex).unwrap();
+    assert_eq!(parsed, digest);
+
+    assert!(matches!(
+        Sha256Digest::parse_hex("abcd"),
+        Err(RewriteError::InvalidDigest { .. })
+    ));
+    assert!(matches!(
+        Sha256Digest::parse_hex(&"z".repeat(64)),
+        Err(RewriteError::InvalidDigest { .. })
+    ));
+    // Uppercase hex is rejected: canonical encoding is lowercase.
+    assert!(matches!(
+        Sha256Digest::parse_hex(&"A".repeat(64)),
+        Err(RewriteError::InvalidDigest { .. })
+    ));
+}
+
+#[cfg(feature = "serialize")]
+#[test]
+fn authority_types_serde_roundtrip() {
+    let mut namespace = LogicVarNamespace::new(3);
+    let var = namespace.fresh();
+    let limits = RelationLimits::new(16, 4, 8, 100).unwrap();
+    let mut resources = RelationResources::new(&limits);
+    resources.record_operations(2).unwrap();
+    let digest = Sha256Digest::framed("amari.relation.term/v1", b"x");
+
+    let var_json = serde_json::to_string(&var).unwrap();
+    assert_eq!(
+        serde_json::from_str::<amari_rewrite::relation::LogicVar>(&var_json).unwrap(),
+        var
+    );
+    for value in [
+        serde_json::to_string(&limits).unwrap(),
+        serde_json::to_string(&resources).unwrap(),
+        serde_json::to_string(&digest).unwrap(),
+        serde_json::to_string(&namespace).unwrap(),
+    ] {
+        assert!(!value.is_empty());
+    }
+    let limits_json = serde_json::to_string(&limits).unwrap();
+    assert_eq!(
+        serde_json::from_str::<RelationLimits>(&limits_json).unwrap(),
+        limits
+    );
+}
+
+#[test]
+fn resources_account_terms_constraints_and_operations() {
+    let limits = RelationLimits::new(8, 2, 3, 5).unwrap();
+    let mut resources = RelationResources::new(&limits);
+
+    // Term accounting: nodes and depth bounded independently.
+    resources.record_term(4, 1).unwrap();
+    assert!(matches!(
+        resources.record_term(9, 1),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    assert!(matches!(
+        resources.record_term(1, 3),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+
+    // Constraint accounting is cumulative.
+    resources.record_constraints(2).unwrap();
+    assert!(matches!(
+        resources.record_constraints(2),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    resources.record_constraints(1).unwrap();
+
+    // Operation accounting is cumulative.
+    resources.record_operations(4).unwrap();
+    assert!(matches!(
+        resources.record_operations(2),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    resources.record_operations(1).unwrap();
+    assert_eq!(resources.operations(), 5);
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 6: constrained relation authority

First Cohort 2 task, per the
[plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md)
and [design](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-design.md)
("Constrained relation model" + "Resource authority").

## New `amari_rewrite::relation` module

- **`LogicVar` / `LogicVarNamespace`** — query-scoped deterministic
  freshening, distinct from display-level `trs::Variable`; same scope →
  identical sequences, different scopes → disjoint identities.
- **`RelationLimits`** — caller-tightenable limits against fixed
  associated-constant ceilings (4,096 nodes/term, depth 64, 4,096
  constraints, 1,000,000 operations — design "Resource authority"
  table). Zero and above-ceiling values are typed `InvalidLimit`
  errors: callers may only tighten.
- **`RelationResources`** — runtime accounting (per-term nodes/depth,
  cumulative constraints/operations) with `RelationLimitExceeded`.
- **`Sha256Digest`** — validated digest with **framed** hashing
  (length-prefixed domain label: identical payloads under different
  frames never collide), canonical lowercase-hex parse/display, and
  **`canonical_term`** — preorder alpha-canonical encoding renumbering
  variables by first structural occurrence. Alpha-equivalent terms hash
  identically; `f(X,Y)` ≠ `f(X,X)`; symbol/variable tags disjoint;
  prefix-free explicit lengths.

New `RewriteError` variants: `InvalidLimit`, `RelationLimitExceeded`,
`InvalidDigest`.

## Deviation recorded

`amari-rewrite` declares `serde` **directly** (not workspace-inherited)
with `default-features = false, features = ["derive", "alloc"]`. The
workspace serde enables std, which would defeat the no_std intent of
`--no-default-features --features serialize` (the design's feature
table keeps `serialize` std-free). Member-level `default-features` is
ignored when the workspace dep omits it (cargo warns), so direct
declaration is the correct mechanism. No other crate is affected.

## Evidence

- **RED→GREEN**: contract tests failed to compile pre-module; now 9/9.
- Feature matrix: default 8/8, **no-default** 8/8, **serialize** 9/9 in
  both std and no_std pairings (serde roundtrips for all four types).
- 17/17 `--all-features` suites; MSRV 1.89 workspace check; clippy
  `-D warnings` both CI invocations; rustdoc `-D warnings`; fmt clean.
- Catalog regenerated **post-fmt** (28 crates, 10,818 items, hash
  `fcfd3cac`; catalog shard 20/20 — source hashes are
  formatting-sensitive, so regen runs last).
- publish-order / version-sync / workflow-crates PASS.

Next: Task 7 — unification and normalized constraints on this
authority.
