### PR TITLE
feat: solve first-order relation constraints (0.25 Cohort 2, Task 7)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "fcfd3cac25693b586dde8cfa9dc97843a56700e08f0f8dabfe5cfab3a833a606",
+  "content_hash": "b7954384c9d1a5bae3d6ebd94a464dee961523052651338510e48bd77286597a",
   "crates": [
     {
       "name": "amari",
@@ -374247,6 +374247,30 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "UnificationFailure",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "reason",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidSubstitution",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -374349,6 +374373,30 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "name": "UnificationFailure",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "reason",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidSubstitution",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -374376,6 +374424,44 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::error",
               "declaration_ident": "RewriteResult"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::unify",
+          "kind": "fn",
+          "signature": "pub fn unify (left : & Term , right : & Term , resources : & mut RelationResources ,) -> RewriteResult < Substitution >",
+          "source_path": "amari-rewrite/src/analysis/unify.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::unify",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn unify (left : & Term , right : & Term , resources : & mut RelationResources ,) -> RewriteResult < Substitution >",
+              "source_path": "amari-rewrite/src/analysis/unify.rs",
+              "source_module": "amari_rewrite::analysis::unify",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::unify",
+              "declaration_ident": "unify"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::unify_with",
+          "kind": "fn",
+          "signature": "pub fn unify_with (substitution : & mut Substitution , left : & Term , right : & Term , resources : & mut RelationResources ,) -> RewriteResult < () >",
+          "source_path": "amari-rewrite/src/analysis/unify.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::unify",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn unify_with (substitution : & mut Substitution , left : & Term , right : & Term , resources : & mut RelationResources ,) -> RewriteResult < () >",
+              "source_path": "amari-rewrite/src/analysis/unify.rs",
+              "source_module": "amari_rewrite::analysis::unify",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::unify",
+              "declaration_ident": "unify_with"
             }
           ]
         },
@@ -374849,6 +374935,30 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "UnificationFailure",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "reason",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidSubstitution",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -374942,6 +375052,30 @@
                   },
                   {
                     "name": "InvalidDigest",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "UnificationFailure",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "reason",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidSubstitution",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -375564,6 +375698,30 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "UnificationFailure",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "reason",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "InvalidSubstitution",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -375657,6 +375815,30 @@
                   },
                   {
                     "name": "InvalidDigest",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "UnificationFailure",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "reason",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "InvalidSubstitution",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -375904,6 +376086,25 @@
           ]
         },
         {
+          "path": "amari_rewrite::prelude::Substitution::compose",
+          "kind": "method",
+          "signature": "pub fn compose (& self , inner : & Self) -> crate :: error :: RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn compose (& self , inner : & Self) -> crate :: error :: RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::compose"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::prelude::Substitution::get",
           "kind": "method",
           "signature": "pub fn get (& self , variable : & str) -> Option < & Term >",
@@ -375961,6 +376162,25 @@
           ]
         },
         {
+          "path": "amari_rewrite::prelude::Substitution::is_empty",
+          "kind": "method",
+          "signature": "pub fn is_empty (& self) -> bool",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn is_empty (& self) -> bool",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::is_empty"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::prelude::Substitution::iter",
           "kind": "method",
           "signature": "pub fn iter (& self) -> impl Iterator < Item = (& Variable , & Term) >",
@@ -375976,6 +376196,25 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::trs::substitution",
               "declaration_ident": "Substitution::iter"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::prelude::Substitution::len",
+          "kind": "method",
+          "signature": "pub fn len (& self) -> usize",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn len (& self) -> usize",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::len"
             }
           ]
         },
@@ -376915,6 +377154,232 @@
           ]
         },
         {
+          "path": "amari_rewrite::relation::ConstraintOutcome",
+          "kind": "enum",
+          "signature": "pub enum ConstraintOutcome",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Satisfiable",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "substitution",
+                      "ty": "Substitution"
+                    },
+                    {
+                      "name": "residuals",
+                      "ty": "Vec < TermConstraint >"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "Unsatisfiable",
+                "data": {
+                  "kind": "unit"
+                }
+              },
+              {
+                "name": "UnsupportedTheory",
+                "data": {
+                  "kind": "unit"
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum ConstraintOutcome",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Satisfiable",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "substitution",
+                          "ty": "Substitution"
+                        },
+                        {
+                          "name": "residuals",
+                          "ty": "Vec < TermConstraint >"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Unsatisfiable",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  },
+                  {
+                    "name": "UnsupportedTheory",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintOutcome"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet",
+          "kind": "struct",
+          "signature": "pub struct ConstraintSet",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct ConstraintSet",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::constraints",
+          "kind": "method",
+          "signature": "pub fn constraints (& self) -> & [TermConstraint]",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn constraints (& self) -> & [TermConstraint]",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::insert",
+          "kind": "method",
+          "signature": "pub fn insert (& mut self , constraint : TermConstraint)",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn insert (& mut self , constraint : TermConstraint)",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::insert"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::is_empty",
+          "kind": "method",
+          "signature": "pub fn is_empty (& self) -> bool",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn is_empty (& self) -> bool",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::is_empty"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::len",
+          "kind": "method",
+          "signature": "pub fn len (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn len (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::len"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::new",
+          "kind": "method",
+          "signature": "pub fn new () -> Self",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new () -> Self",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::normalize",
+          "kind": "method",
+          "signature": "pub fn normalize (& self , limits : & RelationLimits) -> RewriteResult < ConstraintOutcome >",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn normalize (& self , limits : & RelationLimits) -> RewriteResult < ConstraintOutcome >",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "ConstraintSet::normalize"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::relation::LogicVar",
           "kind": "struct",
           "signature": "pub struct LogicVar",
@@ -377559,6 +378024,94 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::relation::digest",
               "declaration_ident": "Sha256Digest::to_hex"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::TermConstraint",
+          "kind": "enum",
+          "signature": "pub enum TermConstraint",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Equal",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "Term",
+                    "Term"
+                  ]
+                }
+              },
+              {
+                "name": "NotEqual",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "Term",
+                    "Term"
+                  ]
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum TermConstraint",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Equal",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "Term",
+                        "Term"
+                      ]
+                    }
+                  },
+                  {
+                    "name": "NotEqual",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "Term",
+                        "Term"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "TermConstraint"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::TermConstraint::canonical_digest",
+          "kind": "method",
+          "signature": "pub fn canonical_digest (& self) -> Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::constraints",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn canonical_digest (& self) -> Sha256Digest",
+              "source_path": "amari-rewrite/src/relation/constraints.rs",
+              "source_module": "amari_rewrite::relation::constraints",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::constraints",
+              "declaration_ident": "TermConstraint::canonical_digest"
             }
           ]
         },
@@ -378279,6 +378832,25 @@
           ]
         },
         {
+          "path": "amari_rewrite::trs::Substitution::compose",
+          "kind": "method",
+          "signature": "pub fn compose (& self , inner : & Self) -> crate :: error :: RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn compose (& self , inner : & Self) -> crate :: error :: RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::compose"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::trs::Substitution::get",
           "kind": "method",
           "signature": "pub fn get (& self , variable : & str) -> Option < & Term >",
@@ -378336,6 +378908,25 @@
           ]
         },
         {
+          "path": "amari_rewrite::trs::Substitution::is_empty",
+          "kind": "method",
+          "signature": "pub fn is_empty (& self) -> bool",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn is_empty (& self) -> bool",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::is_empty"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::trs::Substitution::iter",
           "kind": "method",
           "signature": "pub fn iter (& self) -> impl Iterator < Item = (& Variable , & Term) >",
@@ -378351,6 +378942,25 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::trs::substitution",
               "declaration_ident": "Substitution::iter"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::trs::Substitution::len",
+          "kind": "method",
+          "signature": "pub fn len (& self) -> usize",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::trs::substitution",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn len (& self) -> usize",
+              "source_path": "amari-rewrite/src/trs/substitution.rs",
+              "source_module": "amari_rewrite::trs::substitution",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::trs::substitution",
+              "declaration_ident": "Substitution::len"
             }
           ]
         },
@@ -379428,6 +380038,42 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintSet"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -379511,6 +380157,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::digest",
             "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::TermConstraint",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "TermConstraint"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380023,6 +380687,42 @@
         },
         {
           "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintSet"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -380088,6 +380788,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::limits",
             "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::TermConstraint",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "TermConstraint"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380358,6 +381076,24 @@
             "kind": "local",
             "module": "amari_rewrite::synthesis::anti_unify",
             "ident": "VarGen"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Default",
+          "impl_type_path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Default"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintSet"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380690,6 +381426,42 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintSet"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -380773,6 +381545,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::digest",
             "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::TermConstraint",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "TermConstraint"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381738,6 +382528,42 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "ConstraintSet"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -381821,6 +382647,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::digest",
             "ident": "Sha256Digest"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::TermConstraint",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::constraints",
+            "ident": "TermConstraint"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382403,6 +383247,30 @@
           "surface_kind": "top_level"
         },
         {
+          "path": "amari_rewrite::analysis",
+          "source_path": "amari-rewrite/src/analysis/mod.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "module"
+        },
+        {
+          "path": "amari_rewrite::analysis::unify",
+          "source_path": "amari-rewrite/src/analysis/unify.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::unify_with",
+          "source_path": "amari-rewrite/src/analysis/unify.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
           "path": "amari_rewrite::ars",
           "source_path": "amari-rewrite/src/ars/mod.rs",
           "source_ordinal": 0,
@@ -382835,6 +383703,14 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::prelude::Substitution::compose",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 9,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::prelude::Substitution::get",
           "source_path": "amari-rewrite/src/trs/substitution.rs",
           "source_ordinal": 3,
@@ -382859,9 +383735,25 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::prelude::Substitution::is_empty",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::prelude::Substitution::iter",
           "source_path": "amari-rewrite/src/trs/substitution.rs",
           "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::prelude::Substitution::len",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 7,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"
@@ -383243,6 +384135,70 @@
           "surface_kind": "module"
         },
         {
+          "path": "amari_rewrite::relation::ConstraintOutcome",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::constraints",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::insert",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::is_empty",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::len",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::new",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ConstraintSet::normalize",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -383494,6 +384450,22 @@
           "path": "amari_rewrite::relation::Sha256Digest::to_hex",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::TermConstraint",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::TermConstraint::canonical_digest",
+          "source_path": "amari-rewrite/src/relation/constraints.rs",
+          "source_ordinal": 0,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"
@@ -383819,6 +384791,14 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::trs::Substitution::compose",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 9,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::trs::Substitution::get",
           "source_path": "amari-rewrite/src/trs/substitution.rs",
           "source_ordinal": 3,
@@ -383843,9 +384823,25 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::trs::Substitution::is_empty",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::trs::Substitution::iter",
           "source_path": "amari-rewrite/src/trs/substitution.rs",
           "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::trs::Substitution::len",
+          "source_path": "amari-rewrite/src/trs/substitution.rs",
+          "source_ordinal": 7,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"
@@ -384087,6 +385083,7 @@
       ],
       "modules": [
         "amari_rewrite",
+        "amari_rewrite::analysis",
         "amari_rewrite::ars",
         "amari_rewrite::error",
         "amari_rewrite::inverse",

--- a/amari-rewrite/src/analysis/mod.rs
+++ b/amari-rewrite/src/analysis/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Analysis infrastructure for rewrite systems.
+//!
+//! Currently holds the deterministic first-order unifier shared by
+//! critical pairs, inverse frontier meeting, constraint solving, and
+//! synthesis. Critical pairs, LPO, and confluence land in later
+//! cohorts.
+
+mod unify;
+
+// The module and its primary entry point share the name `unify`;
+// they live in different namespaces, so `analysis::unify(...)` calls
+// the function while `analysis::unify::unify` remains the module path.
+pub use self::unify::{unify, unify_with};

--- a/amari-rewrite/src/analysis/unify.rs
+++ b/amari-rewrite/src/analysis/unify.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic first-order unification with occurs check.
+//!
+//! The worklist algorithm resolves both sides through the
+//! accumulating substitution before every step, so bindings stay
+//! idempotent by construction. Canonical binding order comes from the
+//! substitution's `BTreeMap`; operation and term limits are enforced
+//! through [`RelationResources`].
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::relation::RelationResources;
+use crate::trs::{Substitution, Term, Variable};
+
+/// Most-general unifier of two terms under a fresh substitution.
+pub fn unify(
+    left: &Term,
+    right: &Term,
+    resources: &mut RelationResources,
+) -> RewriteResult<Substitution> {
+    let mut substitution = Substitution::new();
+    unify_with(&mut substitution, left, right, resources)?;
+    Ok(substitution)
+}
+
+/// Extend an existing substitution so `left` and `right` become equal.
+///
+/// On error the substitution may be partially extended; callers treat
+/// failure as terminal for the current goal.
+pub fn unify_with(
+    substitution: &mut Substitution,
+    left: &Term,
+    right: &Term,
+    resources: &mut RelationResources,
+) -> RewriteResult<()> {
+    let mut worklist: Vec<(Term, Term)> = vec![(left.clone(), right.clone())];
+    while let Some((lhs, rhs)) = worklist.pop() {
+        resources.record_operations(1)?;
+        let lhs = resolve(substitution, &lhs);
+        let rhs = resolve(substitution, &rhs);
+        match (&lhs, &rhs) {
+            (Term::Var(x), Term::Var(y)) if x == y => {}
+            (Term::Var(x), term) => {
+                bind(substitution, x, term.clone(), resources)?;
+            }
+            (term, Term::Var(y)) => {
+                bind(substitution, y, term.clone(), resources)?;
+            }
+            (Term::Sym(f, f_args), Term::Sym(g, g_args)) => {
+                if f != g {
+                    return Err(failure("head symbol clash"));
+                }
+                if f_args.len() != g_args.len() {
+                    return Err(failure("arity mismatch"));
+                }
+                for (f_arg, g_arg) in f_args.iter().zip(g_args.iter()) {
+                    worklist.push((f_arg.clone(), g_arg.clone()));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn failure(reason: &str) -> RewriteError {
+    RewriteError::UnificationFailure {
+        reason: String::from(reason),
+    }
+}
+
+/// Resolve a term through the substitution until the root stabilizes.
+fn resolve(substitution: &Substitution, term: &Term) -> Term {
+    match term {
+        Term::Var(variable) => match substitution.get_var(variable) {
+            Some(bound) => resolve(substitution, &bound.clone()),
+            None => term.clone(),
+        },
+        Term::Sym(..) => term.clone(),
+    }
+}
+
+fn bind(
+    substitution: &mut Substitution,
+    variable: &Variable,
+    term: Term,
+    resources: &mut RelationResources,
+) -> RewriteResult<()> {
+    resources.record_term(term_nodes(&term), term_depth(&term))?;
+    if occurs(substitution, variable, &term) {
+        return Err(failure("occurs check violation"));
+    }
+    // `resolve` guarantees the variable is unbound here, and the term
+    // is resolved, so insertion preserves idempotence.
+    substitution.insert(variable.clone(), term);
+    Ok(())
+}
+
+fn occurs(substitution: &Substitution, variable: &Variable, term: &Term) -> bool {
+    let resolved = resolve(substitution, term);
+    match &resolved {
+        Term::Var(other) => other == variable,
+        Term::Sym(_, args) => args.iter().any(|arg| occurs(substitution, variable, arg)),
+    }
+}
+
+/// Count term nodes (variables and symbols).
+pub(crate) fn term_nodes(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_nodes).sum::<usize>(),
+    }
+}
+
+/// Measure term depth (leaf = 1).
+pub(crate) fn term_depth(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_depth).max().unwrap_or(0),
+    }
+}

--- a/amari-rewrite/src/error.rs
+++ b/amari-rewrite/src/error.rs
@@ -43,6 +43,19 @@ pub enum RewriteError {
         /// Validation failure detail.
         message: String,
     },
+    /// First-order unification failed (clash, arity mismatch, or
+    /// occurs-check violation).
+    #[error("unification failed: {reason}")]
+    UnificationFailure {
+        /// Failure detail.
+        reason: String,
+    },
+    /// A substitution failed checked composition or validation.
+    #[error("invalid substitution: {message}")]
+    InvalidSubstitution {
+        /// Validation failure detail.
+        message: String,
+    },
 }
 
 /// Result type used throughout `amari-rewrite`.

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 // reports `Itself`.
 extern crate self as amari_rewrite;
 
+pub mod analysis;
 pub mod ars;
 pub mod error;
 pub mod inverse;

--- a/amari-rewrite/src/relation/constraints.rs
+++ b/amari-rewrite/src/relation/constraints.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Normalized first-order constraint sets.
+//!
+//! Normalization solves equalities through the deterministic unifier,
+//! applies the resulting substitution to disequalities, drops
+//! tautologies, detects contradictions, and retains canonical
+//! residuals. Canonical order and side order use the alpha-canonical
+//! encoding, so results are insertion-order- and name-independent.
+
+use alloc::vec::Vec;
+
+use crate::analysis::unify_with;
+use crate::error::RewriteResult;
+use crate::relation::{RelationLimits, RelationResources, Sha256Digest};
+use crate::trs::{Substitution, Term};
+
+/// A first-order term constraint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum TermConstraint {
+    /// Two terms must be equal.
+    Equal(Term, Term),
+    /// Two terms must remain distinct.
+    NotEqual(Term, Term),
+}
+
+impl TermConstraint {
+    /// Canonical alpha-invariant digest: the constraint is encoded as
+    /// one structure so variables renumber consistently across both
+    /// sides.
+    pub fn canonical_digest(&self) -> Sha256Digest {
+        let mut variables = Vec::new();
+        let mut encoding = Vec::new();
+        match self {
+            Self::Equal(left, right) => {
+                encoding.push(0x10);
+                crate::relation::digest::encode_term(left, &mut variables, &mut encoding);
+                crate::relation::digest::encode_term(right, &mut variables, &mut encoding);
+            }
+            Self::NotEqual(left, right) => {
+                encoding.push(0x11);
+                crate::relation::digest::encode_term(left, &mut variables, &mut encoding);
+                crate::relation::digest::encode_term(right, &mut variables, &mut encoding);
+            }
+        }
+        Sha256Digest::framed("amari.relation.constraint/v1", &encoding)
+    }
+
+    fn canonical_side_order(self) -> Self {
+        match self {
+            Self::NotEqual(left, right) => {
+                let mut variables = Vec::new();
+                let mut left_bytes = Vec::new();
+                crate::relation::digest::encode_term(&left, &mut variables, &mut left_bytes);
+                let mut variables = Vec::new();
+                let mut right_bytes = Vec::new();
+                crate::relation::digest::encode_term(&right, &mut variables, &mut right_bytes);
+                if right_bytes < left_bytes {
+                    Self::NotEqual(right, left)
+                } else {
+                    Self::NotEqual(left, right)
+                }
+            }
+            other => other,
+        }
+    }
+}
+
+/// The result of normalizing a constraint set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConstraintOutcome {
+    /// Equalities solved; residuals are canonical disequalities.
+    Satisfiable {
+        /// The solving substitution.
+        substitution: Substitution,
+        /// Canonical residual disequalities (alpha-canonically
+        /// ordered, sides canonicalized).
+        residuals: Vec<TermConstraint>,
+    },
+    /// The set is contradictory.
+    Unsatisfiable,
+    /// A constraint requires a theory this engine does not support.
+    /// Reserved for theory constraints (SMT bridge cohort); no term
+    /// constraint is ever unsupported.
+    UnsupportedTheory,
+}
+
+/// A set of first-order term constraints.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct ConstraintSet {
+    constraints: Vec<TermConstraint>,
+}
+
+impl ConstraintSet {
+    /// An empty constraint set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a constraint.
+    pub fn insert(&mut self, constraint: TermConstraint) {
+        self.constraints.push(constraint);
+    }
+
+    /// Borrow the raw constraints (insertion order).
+    pub fn constraints(&self) -> &[TermConstraint] {
+        &self.constraints
+    }
+
+    /// Number of constraints.
+    pub fn len(&self) -> usize {
+        self.constraints.len()
+    }
+
+    /// True when empty.
+    pub fn is_empty(&self) -> bool {
+        self.constraints.is_empty()
+    }
+
+    /// Normalize: solve equalities, apply the substitution, drop
+    /// tautologies, detect contradictions, and retain canonical
+    /// disequality residuals.
+    pub fn normalize(&self, limits: &RelationLimits) -> RewriteResult<ConstraintOutcome> {
+        let mut resources = RelationResources::new(limits);
+        resources.record_constraints(self.constraints.len())?;
+
+        let mut substitution = Substitution::new();
+        let mut disequalities: Vec<(Term, Term)> = Vec::new();
+        for constraint in &self.constraints {
+            match constraint {
+                TermConstraint::Equal(left, right) => {
+                    if unify_with(&mut substitution, left, right, &mut resources).is_err() {
+                        return Ok(ConstraintOutcome::Unsatisfiable);
+                    }
+                }
+                TermConstraint::NotEqual(left, right) => {
+                    disequalities.push((left.clone(), right.clone()));
+                }
+            }
+        }
+
+        let mut residuals: Vec<TermConstraint> = Vec::new();
+        for (left, right) in disequalities {
+            let left = substitution.apply(&left);
+            let right = substitution.apply(&right);
+            if left == right {
+                return Ok(ConstraintOutcome::Unsatisfiable);
+            }
+            // Structural tautology check: sides that can never unify
+            // (disjoint heads/arity at every corresponding position)
+            // make the disequality vacuously true. This is a
+            // conservative syntactic check — it never binds variables
+            // and never spends the operation budget on probes.
+            if definitely_distinct(&left, &right) {
+                continue;
+            }
+            residuals.push(TermConstraint::NotEqual(left, right).canonical_side_order());
+        }
+        residuals.sort_by_key(TermConstraint::canonical_digest);
+        residuals.dedup();
+        Ok(ConstraintOutcome::Satisfiable {
+            substitution,
+            residuals,
+        })
+    }
+}
+
+/// Conservative structural check: true when the terms can never unify
+/// (disjoint symbol heads or arities at a corresponding position).
+/// Either side being a variable means "not definitely distinct".
+fn definitely_distinct(left: &Term, right: &Term) -> bool {
+    match (left, right) {
+        (Term::Sym(f, f_args), Term::Sym(g, g_args)) => {
+            f != g
+                || f_args.len() != g_args.len()
+                || f_args
+                    .iter()
+                    .zip(g_args.iter())
+                    .any(|(f_arg, g_arg)| definitely_distinct(f_arg, g_arg))
+        }
+        _ => false,
+    }
+}

--- a/amari-rewrite/src/relation/digest.rs
+++ b/amari-rewrite/src/relation/digest.rs
@@ -97,8 +97,8 @@ fn hex_value(byte: u8) -> Option<u8> {
 
 /// Preorder canonical encoding with alpha-renaming: variables become
 /// indices by first occurrence; structure, arities, and symbol names
-/// are explicit.
-fn encode_term(term: &Term, variables: &mut Vec<String>, out: &mut Vec<u8>) {
+/// are explicit. Shared with constraint canonicalization.
+pub(crate) fn encode_term(term: &Term, variables: &mut Vec<String>, out: &mut Vec<u8>) {
     match term {
         Term::Var(variable) => {
             let name = variable.to_string();

--- a/amari-rewrite/src/relation/mod.rs
+++ b/amari-rewrite/src/relation/mod.rs
@@ -10,10 +10,12 @@
 //! constraint normalization, and backward clauses build on these in
 //! later tasks.
 
-mod digest;
+mod constraints;
+pub(crate) mod digest;
 mod limits;
 mod variable;
 
+pub use constraints::{ConstraintOutcome, ConstraintSet, TermConstraint};
 pub use digest::Sha256Digest;
 pub use limits::{RelationLimits, RelationResources};
 pub use variable::{LogicVar, LogicVarNamespace};

--- a/amari-rewrite/src/trs/substitution.rs
+++ b/amari-rewrite/src/trs/substitution.rs
@@ -6,6 +6,7 @@ use super::{Term, Variable};
 
 /// A variable-to-term substitution.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Substitution {
     map: BTreeMap<Variable, Term>,
 }
@@ -43,13 +44,67 @@ impl Substitution {
     }
 
     /// Apply this substitution recursively to `term`.
+    ///
+    /// Bound ranges are themselves resolved (deep application), so
+    /// unifier-produced substitutions whose ranges mention bound
+    /// variables still normalize fully. Termination follows from the
+    /// occurs check performed at binding time.
     pub fn apply(&self, term: &Term) -> Term {
         match term {
-            Term::Var(var) => self.map.get(var).cloned().unwrap_or_else(|| term.clone()),
+            Term::Var(var) => match self.map.get(var) {
+                Some(bound) => self.apply(&bound.clone()),
+                None => term.clone(),
+            },
             Term::Sym(symbol, args) => Term::Sym(
                 symbol.clone(),
                 args.iter().map(|arg| self.apply(arg)).collect(),
             ),
         }
+    }
+
+    /// Number of bindings.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// True when no bindings exist.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Checked composition `self ∘ inner` (apply `inner`, then `self`).
+    ///
+    /// Rejects incompatible bindings for the same variable and results
+    /// that would not be idempotent (a domain variable occurring in a
+    /// range).
+    pub fn compose(&self, inner: &Self) -> crate::error::RewriteResult<Self> {
+        use crate::error::RewriteError;
+        let invalid = |message: &str| RewriteError::InvalidSubstitution {
+            message: String::from(message),
+        };
+        let mut composed = Self::new();
+        for (variable, term) in &inner.map {
+            let through = self.apply(term);
+            if let Some(outer) = self.map.get(variable) {
+                if *outer != through {
+                    return Err(invalid("incompatible bindings for one variable"));
+                }
+            }
+            composed.insert(variable.clone(), through);
+        }
+        for (variable, term) in &self.map {
+            if !inner.map.contains_key(variable) {
+                composed.insert(variable.clone(), term.clone());
+            }
+        }
+        let non_idempotent = composed
+            .map
+            .values()
+            .flat_map(|term| term.variables())
+            .any(|range| composed.map.contains_key(&range));
+        if non_idempotent {
+            return Err(invalid("composition would not be idempotent"));
+        }
+        Ok(composed)
     }
 }

--- a/amari-rewrite/src/trs/term.rs
+++ b/amari-rewrite/src/trs/term.rs
@@ -7,6 +7,7 @@ use crate::{Path, Rewritable, RewriteError, RewriteResult};
 
 /// A first-order pattern variable.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Variable(String);
 
 impl Variable {
@@ -41,6 +42,7 @@ impl From<String> for Variable {
 
 /// A first-order function or constant symbol.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Symbol(String);
 
 impl Symbol {
@@ -75,6 +77,7 @@ impl From<String> for Symbol {
 
 /// A first-order term.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum Term {
     /// Pattern variable.
     Var(Variable),

--- a/amari-rewrite/tests/constraints.rs
+++ b/amari-rewrite/tests/constraints.rs
@@ -1,0 +1,184 @@
+//! Normalized constraint-set contract tests (0.25 Cohort 2, Task 7).
+//!
+//! `ConstraintSet` normalization solves equalities through the Task 7
+//! unifier, applies the substitution, retains canonical disequality
+//! residuals, and classifies tautology/contradiction deterministically.
+
+use amari_rewrite::relation::{ConstraintOutcome, ConstraintSet, RelationLimits, TermConstraint};
+use amari_rewrite::trs::Term;
+
+fn eq(left: Term, right: Term) -> TermConstraint {
+    TermConstraint::Equal(left, right)
+}
+
+fn ne(left: Term, right: Term) -> TermConstraint {
+    TermConstraint::NotEqual(left, right)
+}
+
+#[test]
+fn tautologies_are_dropped_and_disequalities_kept() {
+    // Equal(t, t) is a tautology and vanishes.
+    let mut set = ConstraintSet::new();
+    set.insert(eq(Term::var("X"), Term::var("X")));
+    let outcome = set.normalize(&RelationLimits::default()).unwrap();
+    let ConstraintOutcome::Satisfiable {
+        substitution,
+        residuals,
+    } = outcome
+    else {
+        panic!("expected satisfiable");
+    };
+    assert!(substitution.is_empty());
+    assert!(residuals.is_empty());
+
+    // NotEqual(f(a), g(b)) is non-unifiable: always true, dropped.
+    let mut set = ConstraintSet::new();
+    set.insert(ne(
+        Term::sym("f", vec![Term::constant("a")]),
+        Term::sym("g", vec![Term::constant("b")]),
+    ));
+    let outcome = set.normalize(&RelationLimits::default()).unwrap();
+    let ConstraintOutcome::Satisfiable { residuals, .. } = outcome else {
+        panic!("expected satisfiable");
+    };
+    assert!(residuals.is_empty());
+
+    // NotEqual(X, a) is a real residual: X could equal a.
+    let mut set = ConstraintSet::new();
+    set.insert(ne(Term::var("X"), Term::constant("a")));
+    let outcome = set.normalize(&RelationLimits::default()).unwrap();
+    let ConstraintOutcome::Satisfiable { residuals, .. } = outcome else {
+        panic!("expected satisfiable");
+    };
+    assert_eq!(residuals.len(), 1);
+}
+
+#[test]
+fn contradictions_are_unsatisfiable() {
+    // Direct: t ≠ t.
+    let mut set = ConstraintSet::new();
+    set.insert(ne(Term::constant("a"), Term::constant("a")));
+    assert!(matches!(
+        set.normalize(&RelationLimits::default()),
+        Ok(ConstraintOutcome::Unsatisfiable)
+    ));
+
+    // Via equality solving: X = a contradicts X ≠ a.
+    let mut set = ConstraintSet::new();
+    set.insert(eq(Term::var("X"), Term::constant("a")));
+    set.insert(ne(Term::var("X"), Term::constant("a")));
+    assert!(matches!(
+        set.normalize(&RelationLimits::default()),
+        Ok(ConstraintOutcome::Unsatisfiable)
+    ));
+
+    // Via unification failure in equalities.
+    let mut set = ConstraintSet::new();
+    set.insert(eq(Term::constant("a"), Term::constant("b")));
+    assert!(matches!(
+        set.normalize(&RelationLimits::default()),
+        Ok(ConstraintOutcome::Unsatisfiable)
+    ));
+}
+
+#[test]
+fn equalities_solve_and_apply_to_residuals() {
+    // X = g(Y) with X ≠ g(a) reduces to residual g(Y) ≠ g(a).
+    let mut set = ConstraintSet::new();
+    set.insert(eq(Term::var("X"), Term::sym("g", vec![Term::var("Y")])));
+    set.insert(ne(
+        Term::var("X"),
+        Term::sym("g", vec![Term::constant("a")]),
+    ));
+    let outcome = set.normalize(&RelationLimits::default()).unwrap();
+    let ConstraintOutcome::Satisfiable {
+        substitution,
+        residuals,
+    } = outcome
+    else {
+        panic!("expected satisfiable");
+    };
+    assert_eq!(
+        substitution.get("X"),
+        Some(&Term::sym("g", vec![Term::var("Y")]))
+    );
+    assert_eq!(residuals.len(), 1);
+    let TermConstraint::NotEqual(left, right) = &residuals[0] else {
+        panic!("expected disequality residual");
+    };
+    // The residual has the solved substitution applied.
+    let rendered = format!("{left:?} != {right:?}");
+    assert!(rendered.contains('g'));
+    assert!(!rendered.contains("\"X\""));
+}
+
+#[test]
+fn normalization_is_deterministic_regardless_of_insertion_order() {
+    let build = |first: TermConstraint, second: TermConstraint, third: TermConstraint| {
+        let mut set = ConstraintSet::new();
+        set.insert(first);
+        set.insert(second);
+        set.insert(third);
+        set.normalize(&RelationLimits::default()).unwrap()
+    };
+    let a = ne(Term::var("X"), Term::constant("a"));
+    let b = ne(Term::var("Y"), Term::constant("b"));
+    let c = ne(Term::var("Z"), Term::constant("c"));
+    let forward = build(a.clone(), b.clone(), c.clone());
+    let reverse = build(c, b, a);
+    let ConstraintOutcome::Satisfiable { residuals: r1, .. } = forward else {
+        panic!("expected satisfiable");
+    };
+    let ConstraintOutcome::Satisfiable { residuals: r2, .. } = reverse else {
+        panic!("expected satisfiable");
+    };
+    assert_eq!(r1, r2, "canonical residual order is insertion-independent");
+}
+
+#[test]
+fn alpha_renamed_sets_normalize_identically() {
+    let build = |x: &str, y: &str| {
+        let mut set = ConstraintSet::new();
+        set.insert(ne(Term::var(x), Term::constant("a")));
+        set.insert(ne(Term::var(y), Term::constant("b")));
+        set.normalize(&RelationLimits::default()).unwrap()
+    };
+    let first = build("X", "Y");
+    let second = build("P", "Q");
+    let ConstraintOutcome::Satisfiable { residuals: r1, .. } = first else {
+        panic!("expected satisfiable");
+    };
+    let ConstraintOutcome::Satisfiable { residuals: r2, .. } = second else {
+        panic!("expected satisfiable");
+    };
+    // Canonical alpha-renumbered digests agree even though names differ.
+    let digest = |constraints: &[TermConstraint]| {
+        constraints
+            .iter()
+            .map(TermConstraint::canonical_digest)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(digest(&r1), digest(&r2));
+}
+
+#[test]
+fn constraint_limits_are_enforced() {
+    let limits = RelationLimits::new(4_096, 64, 2, 1_000_000).unwrap();
+    let mut set = ConstraintSet::new();
+    set.insert(ne(Term::var("X"), Term::constant("a")));
+    set.insert(ne(Term::var("Y"), Term::constant("b")));
+    set.insert(ne(Term::var("Z"), Term::constant("c")));
+    assert!(matches!(
+        set.normalize(&limits),
+        Err(amari_rewrite::RewriteError::RelationLimitExceeded { .. })
+    ));
+}
+
+#[cfg(feature = "serialize")]
+#[test]
+fn constraints_serde_roundtrip() {
+    let constraint = ne(Term::var("X"), Term::sym("f", vec![Term::constant("a")]));
+    let json = serde_json::to_string(&constraint).unwrap();
+    let back: TermConstraint = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, constraint);
+}

--- a/amari-rewrite/tests/unification.rs
+++ b/amari-rewrite/tests/unification.rs
@@ -1,0 +1,193 @@
+//! Unification and checked substitution contract tests
+//! (0.25 Cohort 2, Task 7).
+//!
+//! Deterministic first-order unification with occurs check, canonical
+//! binding order, checked idempotent composition, and strict
+//! term/operation limits. Shared by critical pairs, inverse frontier
+//! meeting, constraints, and synthesis.
+
+use amari_rewrite::analysis::unify;
+use amari_rewrite::relation::{RelationLimits, RelationResources};
+use amari_rewrite::trs::{Substitution, Term};
+use amari_rewrite::RewriteError;
+
+fn resources() -> RelationResources {
+    RelationResources::new(&RelationLimits::default())
+}
+
+#[test]
+fn mgu_binds_variables_deterministically() {
+    let mut budget = resources();
+    let subst = unify(&Term::var("X"), &Term::constant("a"), &mut budget).unwrap();
+    assert_eq!(subst.get("X"), Some(&Term::constant("a")));
+    assert_eq!(subst.len(), 1);
+
+    // Variable-variable: first side binds to the second.
+    let mut budget = resources();
+    let subst = unify(&Term::var("X"), &Term::var("Y"), &mut budget).unwrap();
+    assert_eq!(subst.get("X"), Some(&Term::var("Y")));
+
+    // Structured terms bind both variables.
+    let mut budget = resources();
+    let subst = unify(
+        &Term::sym("f", vec![Term::var("X"), Term::constant("b")]),
+        &Term::sym("f", vec![Term::constant("a"), Term::var("Y")]),
+        &mut budget,
+    )
+    .unwrap();
+    assert_eq!(subst.get("X"), Some(&Term::constant("a")));
+    assert_eq!(subst.get("Y"), Some(&Term::constant("b")));
+}
+
+#[test]
+fn mgu_makes_sides_equal() {
+    let left = Term::sym(
+        "f",
+        vec![Term::var("X"), Term::sym("g", vec![Term::var("X")])],
+    );
+    let right = Term::sym(
+        "f",
+        vec![Term::sym("h", vec![Term::var("Y")]), Term::var("Z")],
+    );
+    let mut budget = resources();
+    let subst = unify(&left, &right, &mut budget).unwrap();
+    assert_eq!(subst.apply(&left), subst.apply(&right));
+}
+
+#[test]
+fn occurs_check_rejects_cyclic_bindings() {
+    let mut budget = resources();
+    let result = unify(
+        &Term::var("X"),
+        &Term::sym("f", vec![Term::var("X")]),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::UnificationFailure { .. })
+    ));
+
+    // Nested: X ~ f(Y), Y ~ g(X) is cyclic through the substitution.
+    let mut budget = resources();
+    let result = unify(
+        &Term::sym("f", vec![Term::var("X"), Term::var("Y")]),
+        &Term::sym(
+            "f",
+            vec![
+                Term::sym("g", vec![Term::var("Y")]),
+                Term::sym("h", vec![Term::var("X")]),
+            ],
+        ),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::UnificationFailure { .. })
+    ));
+}
+
+#[test]
+fn repeated_variables_and_shape_mismatches_fail() {
+    // f(X, X) cannot equal f(a, b).
+    let mut budget = resources();
+    let result = unify(
+        &Term::sym("f", vec![Term::var("X"), Term::var("X")]),
+        &Term::sym("f", vec![Term::constant("a"), Term::constant("b")]),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::UnificationFailure { .. })
+    ));
+
+    // Arity mismatch.
+    let mut budget = resources();
+    let result = unify(
+        &Term::sym("f", vec![Term::var("X")]),
+        &Term::sym("f", vec![Term::var("X"), Term::var("Y")]),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::UnificationFailure { .. })
+    ));
+
+    // Head-symbol clash.
+    let mut budget = resources();
+    let result = unify(
+        &Term::sym("f", vec![Term::var("X")]),
+        &Term::sym("g", vec![Term::var("X")]),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::UnificationFailure { .. })
+    ));
+}
+
+#[test]
+fn alpha_renamed_pairs_unify_isomorphically() {
+    let left = Term::sym("f", vec![Term::var("X"), Term::var("X")]);
+    let right = Term::sym("f", vec![Term::var("Y"), Term::var("Y")]);
+    let mut budget = resources();
+    let subst = unify(&left, &right, &mut budget).unwrap();
+    assert_eq!(subst.apply(&left), subst.apply(&right));
+    // Exactly one binding: X ↦ Y.
+    assert_eq!(subst.len(), 1);
+}
+
+#[test]
+fn checked_composition_combines_and_validates() {
+    // {Y ↦ X} then {X ↦ a} composes to {Y ↦ a, X ↦ a}.
+    let inner = Substitution::new().with("Y", Term::var("X"));
+    let outer = Substitution::new().with("X", Term::constant("a"));
+    let composed = outer.compose(&inner).unwrap();
+    assert_eq!(composed.get("Y"), Some(&Term::constant("a")));
+    assert_eq!(composed.get("X"), Some(&Term::constant("a")));
+
+    // Incompatible bindings for the same variable are rejected.
+    let a = Substitution::new().with("X", Term::constant("a"));
+    let b = Substitution::new().with("X", Term::constant("b"));
+    assert!(matches!(
+        a.compose(&b),
+        Err(RewriteError::InvalidSubstitution { .. })
+    ));
+
+    // Non-idempotent results are rejected: {X ↦ f(Y)} ∘ {Y ↦ X}.
+    let inner = Substitution::new().with("Y", Term::var("X"));
+    let outer = Substitution::new().with("X", Term::sym("f", vec![Term::var("Y")]));
+    assert!(matches!(
+        outer.compose(&inner),
+        Err(RewriteError::InvalidSubstitution { .. })
+    ));
+}
+
+#[test]
+fn unification_respects_operation_limits() {
+    let limits = RelationLimits::new(4_096, 64, 4_096, 2).unwrap();
+    let mut budget = RelationResources::new(&limits);
+    // Three argument pairs exceed a two-operation budget.
+    let result = unify(
+        &Term::sym(
+            "f",
+            vec![
+                Term::constant("a"),
+                Term::constant("b"),
+                Term::constant("c"),
+            ],
+        ),
+        &Term::sym(
+            "f",
+            vec![
+                Term::constant("a"),
+                Term::constant("b"),
+                Term::constant("c"),
+            ],
+        ),
+        &mut budget,
+    );
+    assert!(matches!(
+        result,
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 7: unification and normalized constraints

Per [plan](docs/plans/2026-07-24-amari-rewrite-inverse-expansion-implementation-plan.md)
Task 7 and the design's unification section. Builds on #247's relation
authority.

## New `amari_rewrite::analysis` module

Deterministic first-order unification with occurs check:

- Worklist algorithm resolving both sides through the accumulating
  substitution (bindings idempotent by construction).
- Head clash / arity mismatch / occurs violation → typed
  `RewriteError::UnificationFailure`.
- Every processed pair and bound term accounted against
  `RelationResources` (operation budget exhaustion is a typed error,
  never silent).

## `Substitution` extensions (checked composition)

- `compose` — checked idempotent composition; incompatible bindings
  and non-idempotent results → `InvalidSubstitution`.
- **`apply` now deep-resolves bound ranges.** The unifier can produce
  bindings whose ranges mention bound variables (`Z↦g(X)` with `X`
  bound); deep application is what makes MGU equality
  (`apply(l) == apply(r)`) hold. Rewriting match-ranges never contain
  domain variables, so existing TRS behavior is unchanged — all
  pre-existing suites green.

## New `relation::constraints` module

- `TermConstraint::{Equal, NotEqual}` with `canonical_digest` (the
  constraint encodes as one structure → alpha-consistent renumbering).
- `ConstraintSet::normalize`: solves equalities via the unifier
  (failure classifies `Unsatisfiable`), applies the substitution to
  disequalities, detects contradictions, drops tautologies via a
  conservative structural `definitely_distinct` check (never binds
  variables, never spends budget on probes), and retains canonical
  residuals sorted by alpha-canonical digest with canonicalized side
  order.
- `ConstraintOutcome::{Satisfiable, Unsatisfiable, UnsupportedTheory}` —
  `UnsupportedTheory` is reserved for theory constraints arriving with
  the SMT-bridge cohort; no term constraint is ever unsupported.

## serde coverage fix

`Term`/`Variable`/`Symbol`/`Substitution` gain feature-gated serde
derives — the `serialize` feature predates this cohort but had no
derives anywhere; constraints require them.

## Evidence

- RED→GREEN. 7 unification tests (MGU cases + MGU equality, occurs
  direct and cyclic-through-substitution, repeated variables, arity
  mismatch, head clash, alpha isomorphism, composition
  combine/conflict/non-idempotent, operation limits). 7 constraint
  tests (tautology drop, residuals, three contradiction paths,
  solving applied to residuals, insertion-order determinism,
  alpha-renamed digest equality, limits, serde roundtrip).
- Matrix: default, no-default (21), serialize in both pairings (23).
- 19/19 `--all-features` suites; MSRV 1.89; clippy `-D warnings` both
  CI invocations; rustdoc `-D warnings`; fmt clean.
- Catalog regenerated post-fmt (10,836 items, hash `b7954384`; shard
  20/20); publish-order / workflow-crates / version-sync PASS.

Next: Task 8 — compile rules into symbolic backward clauses on top of
this unifier.
