### PR TITLE
feat: derive symbolic rewrite predecessors (0.25 Cohort 2, Task 8)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "b7954384c9d1a5bae3d6ebd94a464dee961523052651338510e48bd77286597a",
+  "content_hash": "a282411d64763fef8500cb9073d5feb518ff35a13df842d445afd528dfe3e68b",
   "crates": [
     {
       "name": "amari",
@@ -375116,6 +375116,75 @@
           ]
         },
         {
+          "path": "amari_rewrite::inverse::BackwardProvenance",
+          "kind": "struct",
+          "signature": "pub struct BackwardProvenance",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "rule_id",
+                "ty": "RuleId"
+              },
+              {
+                "label": "position",
+                "ty": "Path"
+              },
+              {
+                "label": "scope",
+                "ty": "u32"
+              },
+              {
+                "label": "target_hash",
+                "ty": "Sha256Digest"
+              },
+              {
+                "label": "predecessor_hash",
+                "ty": "Sha256Digest"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BackwardProvenance",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "rule_id",
+                    "ty": "RuleId"
+                  },
+                  {
+                    "label": "position",
+                    "ty": "Path"
+                  },
+                  {
+                    "label": "scope",
+                    "ty": "u32"
+                  },
+                  {
+                    "label": "target_hash",
+                    "ty": "Sha256Digest"
+                  },
+                  {
+                    "label": "predecessor_hash",
+                    "ty": "Sha256Digest"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/mod.rs",
+              "source_module": "amari_rewrite::inverse",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite::inverse",
+              "declaration_ident": "BackwardProvenance"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::inverse::BackwardSearch",
           "kind": "struct",
           "signature": "pub struct BackwardSearch < 'a >",
@@ -375200,6 +375269,83 @@
           ]
         },
         {
+          "path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "kind": "struct",
+          "signature": "pub struct SymbolicPredecessor",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "term",
+                "ty": "Term"
+              },
+              {
+                "label": "existentials",
+                "ty": "Vec < LogicVar >"
+              },
+              {
+                "label": "constraints",
+                "ty": "ConstraintSet"
+              },
+              {
+                "label": "substitution",
+                "ty": "Substitution"
+              },
+              {
+                "label": "provenance",
+                "ty": "BackwardProvenance"
+              },
+              {
+                "label": "resources",
+                "ty": "RelationResources"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct SymbolicPredecessor",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "term",
+                    "ty": "Term"
+                  },
+                  {
+                    "label": "existentials",
+                    "ty": "Vec < LogicVar >"
+                  },
+                  {
+                    "label": "constraints",
+                    "ty": "ConstraintSet"
+                  },
+                  {
+                    "label": "substitution",
+                    "ty": "Substitution"
+                  },
+                  {
+                    "label": "provenance",
+                    "ty": "BackwardProvenance"
+                  },
+                  {
+                    "label": "resources",
+                    "ty": "RelationResources"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/mod.rs",
+              "source_module": "amari_rewrite::inverse",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite::inverse",
+              "declaration_ident": "SymbolicPredecessor"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::inverse::predecessors",
           "kind": "fn",
           "signature": "pub fn predecessors (system : & TermSystem , target : Term , max_depth : usize) -> alloc :: vec :: Vec < Term >",
@@ -375215,6 +375361,25 @@
               "is_reexport": false,
               "declaration_module": "amari_rewrite::inverse",
               "declaration_ident": "predecessors"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::symbolic_predecessors",
+          "kind": "fn",
+          "signature": "pub fn symbolic_predecessors (system : & TermSystem , target : & Term , limits : & RelationLimits , scope : u32 ,) -> RewriteResult < alloc :: vec :: Vec < SymbolicPredecessor > >",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "is_reexport": false,
+          "source_module": "amari_rewrite::inverse",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn symbolic_predecessors (system : & TermSystem , target : & Term , limits : & RelationLimits , scope : u32 ,) -> RewriteResult < alloc :: vec :: Vec < SymbolicPredecessor > >",
+              "source_path": "amari-rewrite/src/inverse/mod.rs",
+              "source_module": "amari_rewrite::inverse",
+              "is_reexport": false,
+              "declaration_module": "amari_rewrite::inverse",
+              "declaration_ident": "symbolic_predecessors"
             }
           ]
         },
@@ -377154,6 +377319,90 @@
           ]
         },
         {
+          "path": "amari_rewrite::relation::BackwardClause",
+          "kind": "struct",
+          "signature": "pub struct BackwardClause",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BackwardClause",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "BackwardClause"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::compile",
+          "kind": "method",
+          "signature": "pub fn compile (rule : & Rule) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn compile (rule : & Rule) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "BackwardClause::compile"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::erased_variables",
+          "kind": "method",
+          "signature": "pub fn erased_variables (& self) -> & [String]",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn erased_variables (& self) -> & [String]",
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "BackwardClause::erased_variables"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::rule_id",
+          "kind": "method",
+          "signature": "pub fn rule_id (& self) -> RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn rule_id (& self) -> RuleId",
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "BackwardClause::rule_id"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::relation::ConstraintOutcome",
           "kind": "enum",
           "signature": "pub enum ConstraintOutcome",
@@ -377883,6 +378132,71 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::relation::limits",
               "declaration_ident": "RelationResources::record_term"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId",
+          "kind": "struct",
+          "signature": "pub struct RuleId",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RuleId",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "RuleId"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId::digest",
+          "kind": "method",
+          "signature": "pub fn digest (& self) -> Sha256Digest",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn digest (& self) -> Sha256Digest",
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "RuleId::digest"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId::from_rule",
+          "kind": "method",
+          "signature": "pub fn from_rule (rule : & Rule) -> Self",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::clause",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn from_rule (rule : & Rule) -> Self",
+              "source_path": "amari-rewrite/src/relation/clause.rs",
+              "source_module": "amari_rewrite::relation::clause",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::clause",
+              "declaration_ident": "RuleId::from_rule"
             }
           ]
         },
@@ -379876,6 +380190,42 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "BackwardProvenance"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::network::RewriteGraphSummary",
           "source_path": "amari-rewrite/src/network/mod.rs",
           "source_ordinal": 0,
@@ -380038,6 +380388,24 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::BackwardClause",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "BackwardClause"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
           "source_path": "amari-rewrite/src/relation/constraints.rs",
           "source_ordinal": 2,
@@ -380139,6 +380507,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::limits",
             "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380416,6 +380802,24 @@
         },
         {
           "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
           "impl_type_path": "amari_rewrite::relation::Sha256Digest",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 0,
@@ -380518,6 +380922,42 @@
             "kind": "local",
             "module": "amari_rewrite::error",
             "ident": "RewriteError"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "BackwardProvenance"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "SymbolicPredecessor"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -380680,6 +381120,24 @@
             "kind": "local",
             "module": "amari_rewrite::synthesis::anti_unify",
             "ident": "VarGen"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::BackwardClause",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "BackwardClause"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381282,6 +381740,42 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "BackwardProvenance"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::network::RewriteGraphSummary",
           "source_path": "amari-rewrite/src/network/mod.rs",
           "source_ordinal": 0,
@@ -381426,6 +381920,24 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::BackwardClause",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "BackwardClause"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
           "source_path": "amari-rewrite/src/relation/constraints.rs",
           "source_ordinal": 2,
@@ -381527,6 +382039,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::limits",
             "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382005,6 +382535,24 @@
         },
         {
           "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
           "impl_type_path": "amari_rewrite::relation::Sha256Digest",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 0,
@@ -382203,6 +382751,24 @@
         },
         {
           "trait_path": "Ord",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Ord"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Ord",
           "impl_type_path": "amari_rewrite::relation::Sha256Digest",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 0,
@@ -382384,6 +382950,42 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "BackwardProvenance"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse",
+            "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::network::RewriteGraphSummary",
           "source_path": "amari-rewrite/src/network/mod.rs",
           "source_ordinal": 0,
@@ -382528,6 +383130,24 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::BackwardClause",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "BackwardClause"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::relation::ConstraintOutcome",
           "source_path": "amari-rewrite/src/relation/constraints.rs",
           "source_ordinal": 2,
@@ -382629,6 +383249,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::limits",
             "ident": "RelationResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382870,6 +383508,24 @@
         },
         {
           "trait_path": "PartialOrd",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialOrd"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialOrd",
           "impl_type_path": "amari_rewrite::relation::Sha256Digest",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 0,
@@ -383036,6 +383692,24 @@
         },
         {
           "trait_path": "fmt::Debug",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "fmt::Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "fmt::Debug",
           "impl_type_path": "amari_rewrite::relation::Sha256Digest",
           "source_path": "amari-rewrite/src/relation/digest.rs",
           "source_ordinal": 6,
@@ -383065,6 +383739,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "fmt::Display",
+          "impl_type_path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "fmt::Display"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::clause",
+            "ident": "RuleId"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -383423,6 +384115,14 @@
           "surface_kind": "module"
         },
         {
+          "path": "amari_rewrite::inverse::BackwardProvenance",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
           "path": "amari_rewrite::inverse::BackwardSearch",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 1,
@@ -383455,9 +384155,25 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::inverse::SymbolicPredecessor",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
           "path": "amari_rewrite::inverse::predecessors",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::symbolic_predecessors",
+          "source_path": "amari-rewrite/src/inverse/mod.rs",
+          "source_ordinal": 6,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "top_level"
@@ -384135,6 +384851,38 @@
           "surface_kind": "module"
         },
         {
+          "path": "amari_rewrite::relation::BackwardClause",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::compile",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::erased_variables",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::BackwardClause::rule_id",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::relation::ConstraintOutcome",
           "source_path": "amari-rewrite/src/relation/constraints.rs",
           "source_ordinal": 2,
@@ -384394,6 +385142,30 @@
           "path": "amari_rewrite::relation::RelationResources::record_term",
           "source_path": "amari-rewrite/src/relation/limits.rs",
           "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId::digest",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RuleId::from_rule",
+          "source_path": "amari-rewrite/src/relation/clause.rs",
+          "source_ordinal": 0,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"

--- a/amari-rewrite/src/inverse/mod.rs
+++ b/amari-rewrite/src/inverse/mod.rs
@@ -5,8 +5,16 @@
 //! subterm and instantiating `lhs` with the same substitution.
 
 use alloc::collections::{BTreeSet, VecDeque};
+use alloc::vec::Vec;
 
-use crate::trs::{match_pattern, Term, TermSystem};
+use crate::analysis::unify;
+use crate::error::RewriteResult;
+use crate::relation::{
+    BackwardClause, ConstraintSet, LogicVar, LogicVarNamespace, RelationLimits, RelationResources,
+    RuleId, Sha256Digest,
+};
+use crate::rewritable::Path;
+use crate::trs::{match_pattern, Substitution, Term, TermSystem};
 
 /// Convenience helper returning all bounded predecessors as a vector.
 pub fn predecessors(system: &TermSystem, target: Term, max_depth: usize) -> alloc::vec::Vec<Term> {
@@ -100,5 +108,116 @@ impl Iterator for BackwardSearch<'_> {
         }
 
         None
+    }
+}
+
+/// Provenance of one symbolic backward step: stable rule identity,
+/// target position, freshening scope, and authority hashes. Contains
+/// no source text, filesystem paths, or backend diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BackwardProvenance {
+    /// The checked rule's stable identity.
+    pub rule_id: RuleId,
+    /// Position of the replaced subterm in the target.
+    pub position: Path,
+    /// Freshening namespace scope of the query.
+    pub scope: u32,
+    /// Canonical digest of the target term.
+    pub target_hash: Sha256Digest,
+    /// Canonical digest of the predecessor term.
+    pub predecessor_hash: Sha256Digest,
+}
+
+/// One symbolic backward transition: a predecessor term together with
+/// its existentials, constraints, unifying substitution, provenance,
+/// and the resources consumed while deriving it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct SymbolicPredecessor {
+    /// The predecessor term (with freshened logic variables).
+    pub term: Term,
+    /// Existential logic variables (LHS variables erased forward).
+    pub existentials: Vec<LogicVar>,
+    /// Constraints on this predecessor (empty until grounding and
+    /// bidirectional analysis introduce them).
+    pub constraints: ConstraintSet,
+    /// The unifying substitution over freshened variables.
+    pub substitution: Substitution,
+    /// Step provenance.
+    pub provenance: BackwardProvenance,
+    /// Resource usage snapshot at the point this predecessor was
+    /// derived.
+    pub resources: RelationResources,
+}
+
+/// Symbolic one-step predecessors of `target` under `system`.
+///
+/// Enumerates target positions in preorder (position-major) and rules
+/// in system order; each attempt freshens its clause from one
+/// query-scoped namespace, so results are deterministic per
+/// `(system, target, scope)`. Self-loop predecessors (equal to the
+/// target) are excluded. Unification clashes skip the attempt;
+/// resource breaches are typed errors.
+pub fn symbolic_predecessors(
+    system: &TermSystem,
+    target: &Term,
+    limits: &RelationLimits,
+    scope: u32,
+) -> RewriteResult<alloc::vec::Vec<SymbolicPredecessor>> {
+    let mut resources = RelationResources::new(limits);
+    resources.record_term(term_nodes(target), term_depth(target))?;
+    let mut namespace = LogicVarNamespace::new(scope);
+    let target_hash = Sha256Digest::canonical_term("amari.relation.term/v1", target);
+    let mut out = alloc::vec::Vec::new();
+    for path in target.positions() {
+        let Some(subterm) = target.subterm(&path) else {
+            continue;
+        };
+        for rule in system.rules() {
+            let clause = BackwardClause::compile(rule)?;
+            let fresh = clause.freshen(&mut namespace);
+            let substitution = match unify(&fresh.rhs, subterm, &mut resources) {
+                Ok(substitution) => substitution,
+                Err(crate::error::RewriteError::UnificationFailure { .. }) => continue,
+                Err(error) => return Err(error),
+            };
+            let predecessor_subterm = substitution.apply(&fresh.lhs);
+            let predecessor = target.replace_at(&path, predecessor_subterm)?;
+            if predecessor == *target {
+                continue;
+            }
+            let predecessor_hash =
+                Sha256Digest::canonical_term("amari.relation.term/v1", &predecessor);
+            out.push(SymbolicPredecessor {
+                term: predecessor,
+                existentials: fresh.erased.clone(),
+                constraints: ConstraintSet::new(),
+                substitution,
+                provenance: BackwardProvenance {
+                    rule_id: clause.rule_id(),
+                    position: path.clone(),
+                    scope,
+                    target_hash,
+                    predecessor_hash,
+                },
+                resources: resources.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn term_nodes(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_nodes).sum::<usize>(),
+    }
+}
+
+fn term_depth(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_depth).max().unwrap_or(0),
     }
 }

--- a/amari-rewrite/src/relation/clause.rs
+++ b/amari-rewrite/src/relation/clause.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Backward clauses compiled from checked rules.
+//!
+//! A [`BackwardClause`] wraps a checked [`Rule`] with its stable
+//! identity digest and precomputed erased variables (LHS variables
+//! absent from the RHS — the information a forward step destroys).
+//! Freshening allocates from a deterministic query-scoped
+//! [`LogicVarNamespace`] so backward applications never capture target
+//! or rule variables.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use core::fmt;
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::relation::digest::encode_term;
+use crate::relation::{LogicVar, LogicVarNamespace, Sha256Digest};
+use crate::trs::{Rule, Substitution, Term};
+
+/// Stable rule identity: the canonical digest of the checked rule's
+/// LHS/RHS pair under the rule frame.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RuleId(Sha256Digest);
+
+impl RuleId {
+    /// Compute the identity of a checked rule.
+    pub fn from_rule(rule: &Rule) -> Self {
+        let mut variables = Vec::new();
+        let mut encoding = Vec::new();
+        encode_term(rule.lhs(), &mut variables, &mut encoding);
+        encode_term(rule.rhs(), &mut variables, &mut encoding);
+        Self(Sha256Digest::framed("amari.relation.rule/v1", &encoding))
+    }
+
+    /// The underlying digest.
+    pub fn digest(&self) -> Sha256Digest {
+        self.0
+    }
+}
+
+impl fmt::Display for RuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for RuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RuleId({})", self.0)
+    }
+}
+
+/// A rule compiled for backward application.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BackwardClause {
+    rule_id: RuleId,
+    lhs: Term,
+    rhs: Term,
+    /// LHS variables absent from the RHS (erased forward; existential
+    /// backward), in sorted order.
+    erased: Vec<String>,
+}
+
+impl BackwardClause {
+    /// Compile a checked rule. Defensively re-verifies the checked
+    /// invariant (RHS variables ⊆ LHS variables): a clause must never
+    /// exist for a rule that invents information backward.
+    pub fn compile(rule: &Rule) -> RewriteResult<Self> {
+        let lhs_vars: Vec<String> = rule
+            .lhs()
+            .variables()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        for variable in rule.rhs().variables() {
+            let name = variable.to_string();
+            if !lhs_vars.contains(&name) {
+                return Err(RewriteError::InvalidRule {
+                    message: String::from(
+                        "backward clause requires RHS variables to occur \
+                         in the LHS",
+                    ),
+                });
+            }
+        }
+        let mut erased: Vec<String> = {
+            let rhs_vars: Vec<String> = rule
+                .rhs()
+                .variables()
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            lhs_vars
+                .iter()
+                .filter(|name| !rhs_vars.contains(*name))
+                .cloned()
+                .collect()
+        };
+        erased.sort();
+        erased.dedup();
+        Ok(Self {
+            rule_id: RuleId::from_rule(rule),
+            lhs: rule.lhs().clone(),
+            rhs: rule.rhs().clone(),
+            erased,
+        })
+    }
+
+    /// Stable rule identity.
+    pub fn rule_id(&self) -> RuleId {
+        self.rule_id
+    }
+
+    /// Variables erased by the forward direction (existential
+    /// backward), sorted.
+    pub fn erased_variables(&self) -> &[String] {
+        &self.erased
+    }
+
+    /// Freshen the clause under the namespace: rule variables become
+    /// logic variables named by their `LogicVar` display form.
+    pub(crate) fn freshen(&self, namespace: &mut LogicVarNamespace) -> FreshenedClause {
+        let mut renaming = Substitution::new();
+        let mut erased_vars = Vec::new();
+        let mut variables: Vec<String> = self
+            .lhs
+            .variables()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        variables.sort();
+        variables.dedup();
+        for name in &variables {
+            let logic = namespace.fresh();
+            renaming.insert(name.clone(), Term::var(logic.to_string()));
+            if self.erased.contains(name) {
+                erased_vars.push(logic);
+            }
+        }
+        FreshenedClause {
+            lhs: renaming.apply(&self.lhs),
+            rhs: renaming.apply(&self.rhs),
+            erased: erased_vars,
+        }
+    }
+}
+
+/// A clause with rule variables renamed into a query scope.
+pub(crate) struct FreshenedClause {
+    pub lhs: Term,
+    pub rhs: Term,
+    /// Logic variables for the erased (existential) variables.
+    pub erased: Vec<LogicVar>,
+}

--- a/amari-rewrite/src/relation/mod.rs
+++ b/amari-rewrite/src/relation/mod.rs
@@ -10,11 +10,13 @@
 //! constraint normalization, and backward clauses build on these in
 //! later tasks.
 
+mod clause;
 mod constraints;
 pub(crate) mod digest;
 mod limits;
 mod variable;
 
+pub use clause::{BackwardClause, RuleId};
 pub use constraints::{ConstraintOutcome, ConstraintSet, TermConstraint};
 pub use digest::Sha256Digest;
 pub use limits::{RelationLimits, RelationResources};

--- a/amari-rewrite/src/rewritable.rs
+++ b/amari-rewrite/src/rewritable.rs
@@ -8,6 +8,7 @@ use crate::{RewriteError, RewriteResult};
 /// The empty path is the root. Each component is a child index at the current
 /// node.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Path(Vec<usize>);
 
 impl Path {

--- a/amari-rewrite/tests/symbolic_predecessors.rs
+++ b/amari-rewrite/tests/symbolic_predecessors.rs
@@ -1,0 +1,228 @@
+//! Symbolic predecessor contract tests (0.25 Cohort 2, Task 8).
+//!
+//! Backward application unifies a freshened rule RHS with each target
+//! subterm and instantiates the LHS. Results carry existentials (LHS
+//! variables absent from the RHS), constraints, substitution,
+//! provenance, and resources. Every symbolic predecessor must satisfy
+//! the bounded-grounding forward-replay oracle. The legacy
+//! `predecessors` iterator behavior is pinned unchanged.
+
+use amari_rewrite::inverse::{predecessors, symbolic_predecessors, SymbolicPredecessor};
+use amari_rewrite::relation::{LogicVar, RelationLimits};
+use amari_rewrite::trs::{Rule, Substitution, Term, TermSystem};
+use amari_rewrite::RewriteError;
+
+fn system(rules: Vec<(&str, &str)>) -> TermSystem {
+    let parsed = rules
+        .into_iter()
+        .map(|(lhs, rhs)| Rule::new(parse(lhs), parse(rhs)).unwrap())
+        .collect();
+    TermSystem::new(parsed)
+}
+
+/// Tiny parser for test terms: `a`, `f(a)`, `f(X, a)`.
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+fn limits() -> RelationLimits {
+    RelationLimits::default()
+}
+
+/// The mandatory oracle: ground every free variable with one constant
+/// and confirm the predecessor forward-rewrites to the target.
+fn assert_forward_replays(sys: &TermSystem, target: &Term, predecessor: &SymbolicPredecessor) {
+    let mut grounding = Substitution::new();
+    for variable in target.variables() {
+        grounding.insert(variable, Term::constant("zz"));
+    }
+    for variable in predecessor.term.variables() {
+        grounding.insert(variable, Term::constant("zz"));
+    }
+    let concrete_source = grounding.apply(&predecessor.term);
+    let concrete_target = grounding.apply(target);
+    let successors = sys.successors(&concrete_source).unwrap();
+    assert!(
+        successors.contains(&concrete_target),
+        "forward replay failed: {concrete_source:?} does not reach \
+         {concrete_target:?} via {successors:?}"
+    );
+}
+
+#[test]
+fn direct_and_nested_predecessors() {
+    let sys = system(vec![("a", "b")]);
+    let preds = symbolic_predecessors(&sys, &parse("b"), &limits(), 0).unwrap();
+    assert_eq!(preds.len(), 1);
+    assert_eq!(preds[0].term, parse("a"));
+    assert!(preds[0].provenance.position.is_root());
+    assert!(preds[0].existentials.is_empty());
+
+    let sys = system(vec![("f(X)", "g(X)")]);
+    let preds = symbolic_predecessors(&sys, &parse("h(g(a))"), &limits(), 0).unwrap();
+    assert_eq!(preds.len(), 1);
+    assert_eq!(preds[0].term, parse("h(f(a))"));
+    assert_eq!(preds[0].provenance.position.as_slice(), &[0]);
+}
+
+#[test]
+fn freshening_avoids_capture_and_is_deterministic() {
+    // Rule variable X collides with the target's free variable Y only
+    // in name space; freshening must keep them apart.
+    let sys = system(vec![("f(X)", "X")]);
+    let target = parse("g(Y)");
+    let first = symbolic_predecessors(&sys, &target, &limits(), 0).unwrap();
+    let second = symbolic_predecessors(&sys, &target, &limits(), 0).unwrap();
+    // Positions: root (f(g(Y))) and the variable leaf (g(f(Y))).
+    assert_eq!(first.len(), 2);
+    // Same query scope: identical results across runs.
+    assert_eq!(first, second);
+    for predecessor in &first {
+        let names: Vec<String> = predecessor
+            .term
+            .variables()
+            .iter()
+            .map(|v| v.to_string())
+            .collect();
+        // The rule's raw variable name must never leak: freshening
+        // prevents capture between rule and target variables.
+        assert!(!names.iter().any(|n| n == "X"));
+        // Freshened logic variables appear in root-position results.
+        assert!(names.iter().all(|n| n == "Y" || n.starts_with('?')));
+    }
+    // Different scope: disjoint freshened variables.
+    let other = symbolic_predecessors(&sys, &target, &limits(), 1).unwrap();
+    assert_ne!(first, other);
+}
+
+#[test]
+fn erased_variables_become_existentials() {
+    // Y occurs only in the LHS: backward application introduces it as
+    // an existential.
+    let sys = system(vec![("f(X, Y)", "g(X)")]);
+    let preds = symbolic_predecessors(&sys, &parse("g(a)"), &limits(), 0).unwrap();
+    assert_eq!(preds.len(), 1);
+    assert_eq!(preds[0].existentials.len(), 1);
+    let existential = preds[0].existentials[0];
+    let rendered = format!("{:?}", preds[0].term);
+    assert!(rendered.contains(&existential.to_string()));
+    // The oracle must hold despite the existential.
+    assert_forward_replays(&sys, &parse("g(a)"), &preds[0]);
+}
+
+#[test]
+fn repeated_rhs_variables_and_impossible_matches() {
+    let sys = system(vec![("h(X)", "k(X, X)")]);
+    // k(a, b) cannot unify with k(X, X).
+    assert!(symbolic_predecessors(&sys, &parse("k(a, b)"), &limits(), 0)
+        .unwrap()
+        .is_empty());
+    // k(a, a) yields h(a).
+    let preds = symbolic_predecessors(&sys, &parse("k(a, a)"), &limits(), 0).unwrap();
+    assert_eq!(preds.len(), 1);
+    assert_eq!(preds[0].term, parse("h(a)"));
+
+    // No rule RHS matches any subterm.
+    let sys = system(vec![("f(X)", "g(X)")]);
+    assert!(symbolic_predecessors(&sys, &parse("h(a)"), &limits(), 0)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn cyclic_self_loop_predecessors_are_excluded() {
+    let sys = system(vec![("X", "X")]);
+    assert!(symbolic_predecessors(&sys, &parse("a"), &limits(), 0)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn provenance_records_identity_position_and_order() {
+    let sys = system(vec![("a", "b"), ("c", "b")]);
+    let preds = symbolic_predecessors(&sys, &parse("b"), &limits(), 0).unwrap();
+    assert_eq!(preds.len(), 2);
+    // Enumeration order is position-major, rule order within.
+    assert_eq!(preds[0].term, parse("a"));
+    assert_eq!(preds[1].term, parse("c"));
+    // Rule identities are stable digests and distinct per rule.
+    assert_ne!(preds[0].provenance.rule_id, preds[1].provenance.rule_id);
+    // Authority hashes match the actual terms.
+    assert_eq!(
+        preds[0].provenance.predecessor_hash,
+        amari_rewrite::relation::Sha256Digest::canonical_term(
+            "amari.relation.term/v1",
+            &preds[0].term
+        )
+    );
+    assert_eq!(preds[0].provenance.scope, 0);
+
+    // Nested positions enumerate in preorder before deeper ones.
+    let sys = system(vec![("a", "b")]);
+    let preds = symbolic_predecessors(&sys, &parse("f(b, b)"), &limits(), 0).unwrap();
+    let positions: Vec<_> = preds
+        .iter()
+        .map(|p| p.provenance.position.as_slice().to_vec())
+        .collect();
+    assert_eq!(positions, vec![vec![0], vec![1]]);
+}
+
+#[test]
+fn limits_are_enforced_during_backward_application() {
+    let sys = system(vec![("f(X)", "g(X)")]);
+    // Operation budget too small to process the unification pairs.
+    let tight = RelationLimits::new(4_096, 64, 4_096, 1).unwrap();
+    assert!(matches!(
+        symbolic_predecessors(&sys, &parse("g(g(a))"), &tight, 0),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    // Term depth budget rejects the target itself.
+    let shallow = RelationLimits::new(4_096, 1, 4_096, 1_000_000).unwrap();
+    assert!(matches!(
+        symbolic_predecessors(&sys, &parse("g(g(a))"), &shallow, 0),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+}
+
+#[test]
+fn legacy_backward_search_behavior_is_unchanged() {
+    // Regression pin: legacy iterator results for a known system.
+    let sys = system(vec![("f(X)", "g(X)"), ("a", "b")]);
+    let target = parse("g(a)");
+    let legacy = predecessors(&sys, target.clone(), 1);
+    assert_eq!(legacy, vec![parse("f(a)")]);
+
+    let deep = predecessors(&sys, parse("g(b)"), 2);
+    assert!(deep.contains(&parse("f(b)")));
+    assert!(deep.contains(&parse("f(a)")));
+}
+
+#[test]
+fn logic_var_display_is_stable() {
+    let var = LogicVar::new(3, 7);
+    assert_eq!(var.to_string(), "?3.7");
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 8: symbolic backward clauses and predecessors

Per plan Task 8 and the design's "Symbolic predecessors" section. First
Morphogen-facing machinery: the exact predecessor relation over checked
rules.

## `relation::BackwardClause` + `RuleId`

- Compiled from a checked `trs::Rule`; compilation **defensively
  re-verifies** RHS variables ⊆ LHS variables (a clause must never
  exist for a rule that invents information backward).
- `RuleId` = canonical framed digest of the LHS/RHS pair — stable
  identity that disambiguates rules with identical RHS.
- Erased variables (LHS-only) precomputed, sorted: they become
  existentials backward.
- Freshening renames rule variables into a deterministic query-scoped
  `LogicVarNamespace`; raw rule names never leak into predecessors and
  target variables are never captured.

## `inverse::symbolic_predecessors`

`symbolic_predecessors(system, target, limits, scope)`:

- Positions preorder (position-major) × rules in system order; one
  namespace per query → deterministic per `(system, target, scope)`
  (tested: same scope ⇒ identical results; different scope ⇒ disjoint).
- Freshened RHS unified with each subterm via the Task 7 unifier;
  LHS instantiated; self-loops excluded; clashes skip; resource
  breaches are typed errors.
- Returns `SymbolicPredecessor { term, existentials, constraints,
  substitution, provenance, resources }` per the design struct;
  `BackwardProvenance` = rule identity + position + scope +
  target/predecessor authority hashes (no source text/paths/backend
  diagnostics).

## Mandatory forward-replay oracle

Every existential-carrying predecessor is grounded (existentials ↦
constant) and replayed: `system.successors(grounded predecessor)` must
contain the grounded target. Encoded as a reusable test oracle.

## Legacy pinned

`predecessors`/`BackwardSearch` untouched; regression tests pin exact
legacy outputs.

## Evidence

RED→GREEN; 9 contract tests covering the plan's RED list (direct/root/
nested, fresh variables, erased variables, repeated RHS variables,
impossible match, cyclic target, provenance order, all limits) plus
the oracle and legacy regression. Matrix: default/no-default (30 across
four rewrite suites), serialize both pairings (32); 20/20
`--all-features`; MSRV 1.89; clippy `-D warnings` ×2; rustdoc
`-D warnings`; fmt clean; catalog post-fmt (10,846 items, `a282411d`;
shard 20/20); publish-order/workflow-crates PASS.

Next: Task 9 — finite grounding domains (canonical enumeration,
constraint validation before emission).
