### PR TITLE
feat: ground symbolic predecessors safely (0.25 Cohort 2, Task 9)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "a282411d64763fef8500cb9073d5feb518ff35a13df842d445afd528dfe3e68b",
+  "content_hash": "4e6acc8d1eb14f3ecbfea2d8c96d42628a656bd260e5d8aa73b36a7774620095",
   "crates": [
     {
       "name": "amari",
@@ -377629,6 +377629,288 @@
           ]
         },
         {
+          "path": "amari_rewrite::relation::GroundedPredecessor",
+          "kind": "struct",
+          "signature": "pub struct GroundedPredecessor",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "substitution",
+                "ty": "Substitution"
+              },
+              {
+                "label": "term",
+                "ty": "Term"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct GroundedPredecessor",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "substitution",
+                    "ty": "Substitution"
+                  },
+                  {
+                    "label": "term",
+                    "ty": "Term"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundedPredecessor"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain",
+          "kind": "struct",
+          "signature": "pub struct GroundingDomain",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct GroundingDomain",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_DEPTH",
+          "kind": "const",
+          "signature": "pub const MAX_DEPTH : usize",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_DEPTH : usize",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::MAX_DEPTH"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_RANK",
+          "kind": "const",
+          "signature": "pub const MAX_RANK : usize",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_RANK : usize",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::MAX_RANK"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_SYMBOLS",
+          "kind": "const",
+          "signature": "pub const MAX_SYMBOLS : usize",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_SYMBOLS : usize",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::MAX_SYMBOLS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_TERMS",
+          "kind": "const",
+          "signature": "pub const MAX_TERMS : usize",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TERMS : usize",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::MAX_TERMS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::enumerate",
+          "kind": "method",
+          "signature": "pub fn enumerate (& self , resources : & mut RelationResources) -> RewriteResult < Vec < Term > >",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn enumerate (& self , resources : & mut RelationResources) -> RewriteResult < Vec < Term > >",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::enumerate"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::new",
+          "kind": "method",
+          "signature": "pub fn new (symbols : Vec < RankedSymbol > , max_depth : usize , max_terms : usize ,) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (symbols : Vec < RankedSymbol > , max_depth : usize , max_terms : usize ,) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::symbols",
+          "kind": "method",
+          "signature": "pub fn symbols (& self) -> & [RankedSymbol]",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn symbols (& self) -> & [RankedSymbol]",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingDomain::symbols"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingOutcome",
+          "kind": "enum",
+          "signature": "pub enum GroundingOutcome",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Complete",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "grounded",
+                      "ty": "Vec < GroundedPredecessor >"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "Partial",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "grounded",
+                      "ty": "Vec < GroundedPredecessor >"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum GroundingOutcome",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Complete",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "grounded",
+                          "ty": "Vec < GroundedPredecessor >"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Partial",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "grounded",
+                          "ty": "Vec < GroundedPredecessor >"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "GroundingOutcome"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::relation::LogicVar",
           "kind": "struct",
           "signature": "pub struct LogicVar",
@@ -377793,6 +378075,90 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::relation::variable",
               "declaration_ident": "LogicVarNamespace::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol",
+          "kind": "struct",
+          "signature": "pub struct RankedSymbol",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RankedSymbol",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "RankedSymbol"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::arity",
+          "kind": "method",
+          "signature": "pub fn arity (& self) -> usize",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn arity (& self) -> usize",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "RankedSymbol::arity"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::name",
+          "kind": "method",
+          "signature": "pub fn name (& self) -> & str",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn name (& self) -> & str",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "RankedSymbol::name"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::new",
+          "kind": "method",
+          "signature": "pub fn new (name : impl Into < String > , arity : usize) -> Self",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (name : impl Into < String > , arity : usize) -> Self",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "RankedSymbol::new"
             }
           ]
         },
@@ -378426,6 +378792,25 @@
               "is_reexport": true,
               "declaration_module": "amari_rewrite::relation::constraints",
               "declaration_ident": "TermConstraint::canonical_digest"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::relation::ground_predecessor",
+          "kind": "fn",
+          "signature": "pub fn ground_predecessor (system : & TermSystem , target : & Term , predecessor : & SymbolicPredecessor , domain : & GroundingDomain , limits : & RelationLimits ,) -> RewriteResult < GroundingOutcome >",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::relation::ground",
+          "variants": [
+            {
+              "kind": "fn",
+              "signature": "pub fn ground_predecessor (system : & TermSystem , target : & Term , predecessor : & SymbolicPredecessor , domain : & GroundingDomain , limits : & RelationLimits ,) -> RewriteResult < GroundingOutcome >",
+              "source_path": "amari-rewrite/src/relation/ground.rs",
+              "source_module": "amari_rewrite::relation::ground",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::relation::ground",
+              "declaration_ident": "ground_predecessor"
             }
           ]
         },
@@ -380442,6 +380827,60 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::GroundedPredecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundedPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::GroundingDomain",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingDomain"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::GroundingOutcome",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -380471,6 +380910,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381181,6 +381638,60 @@
         },
         {
           "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::GroundedPredecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundedPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::GroundingDomain",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingDomain"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::GroundingOutcome",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -381210,6 +381721,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381974,6 +382503,60 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::GroundedPredecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundedPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::GroundingDomain",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingDomain"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::GroundingOutcome",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -382003,6 +382586,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382535,6 +383136,24 @@
         },
         {
           "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
           "impl_type_path": "amari_rewrite::relation::RuleId",
           "source_path": "amari-rewrite/src/relation/clause.rs",
           "source_ordinal": 0,
@@ -382744,6 +383363,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Ord",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Ord"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -383184,6 +383821,60 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::GroundedPredecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundedPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::GroundingDomain",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingDomain"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::GroundingOutcome",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "GroundingOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -383213,6 +383904,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVarNamespace"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -383501,6 +384210,24 @@
             "kind": "local",
             "module": "amari_rewrite::relation::variable",
             "ident": "LogicVar"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialOrd",
+          "impl_type_path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialOrd"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::relation::ground",
+            "ident": "RankedSymbol"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -384947,6 +385674,86 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::relation::GroundedPredecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_DEPTH",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_RANK",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_SYMBOLS",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::MAX_TERMS",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::enumerate",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::new",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingDomain::symbols",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::GroundingOutcome",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
           "path": "amari_rewrite::relation::LogicVar",
           "source_path": "amari-rewrite/src/relation/variable.rs",
           "source_ordinal": 0,
@@ -385005,6 +385812,38 @@
         {
           "path": "amari_rewrite::relation::LogicVarNamespace::new",
           "source_path": "amari-rewrite/src/relation/variable.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::arity",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::name",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::RankedSymbol::new",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
           "source_ordinal": 0,
           "gate": "always",
           "status": "enabled",
@@ -385241,6 +386080,14 @@
           "gate": "always",
           "status": "enabled",
           "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::relation::ground_predecessor",
+          "source_path": "amari-rewrite/src/relation/ground.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
         },
         {
           "path": "amari_rewrite::rewritable",

--- a/amari-rewrite/src/relation/ground.rs
+++ b/amari-rewrite/src/relation/ground.rs
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Finite grounding domains and safe existential grounding.
+//!
+//! A [`GroundingDomain`] is a caller-supplied finite ranked symbol
+//! domain with depth/count ceilings (fixed ceilings: 256 symbols,
+//! rank 16, depth 16, 65,536 emitted terms). Enumeration is canonical:
+//! ascending node count, then head-symbol (name, arity) order, then
+//! lexicographic children. [`ground_predecessor`] assigns a
+//! predecessor's existentials from the domain in canonical order and
+//! validates constraints and forward replay before emitting — every
+//! emitted grounding is replay-validated by construction.
+
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::inverse::SymbolicPredecessor;
+use crate::relation::{RelationLimits, RelationResources, TermConstraint};
+use crate::trs::{Substitution, Term, TermSystem, Variable};
+
+/// A ranked domain symbol: a name with a fixed arity.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RankedSymbol {
+    name: String,
+    arity: usize,
+}
+
+impl RankedSymbol {
+    /// A ranked symbol (rank validated by [`GroundingDomain::new`]).
+    pub fn new(name: impl Into<String>, arity: usize) -> Self {
+        Self {
+            name: name.into(),
+            arity,
+        }
+    }
+
+    /// Symbol name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Fixed arity.
+    pub fn arity(&self) -> usize {
+        self.arity
+    }
+}
+
+/// A validated finite ranked symbol domain.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct GroundingDomain {
+    /// Sorted by (name, arity) at construction: declaration order
+    /// never affects enumeration.
+    symbols: Vec<RankedSymbol>,
+    max_depth: usize,
+    max_terms: usize,
+}
+
+impl GroundingDomain {
+    /// Hard ceiling on ranked symbols per domain.
+    pub const MAX_SYMBOLS: usize = 256;
+    /// Hard ceiling on symbol rank.
+    pub const MAX_RANK: usize = 16;
+    /// Hard ceiling on enumerated term depth.
+    pub const MAX_DEPTH: usize = 16;
+    /// Hard ceiling on emitted terms.
+    pub const MAX_TERMS: usize = 65_536;
+
+    /// Validate a domain. Empty domains, domains without constants (no
+    /// finite term is constructible), duplicate ranked symbols, and
+    /// zero/above-ceiling depth or term counts all fail before any
+    /// allocation happens.
+    pub fn new(
+        symbols: Vec<RankedSymbol>,
+        max_depth: usize,
+        max_terms: usize,
+    ) -> RewriteResult<Self> {
+        let invalid =
+            |resource: &'static str, value: usize, ceiling: usize| RewriteError::InvalidLimit {
+                resource,
+                value,
+                ceiling,
+            };
+        if symbols.is_empty() || symbols.len() > Self::MAX_SYMBOLS {
+            return Err(invalid(
+                "grounding symbols",
+                symbols.len(),
+                Self::MAX_SYMBOLS,
+            ));
+        }
+        if let Some(symbol) = symbols.iter().find(|s| s.arity > Self::MAX_RANK) {
+            return Err(invalid("grounding rank", symbol.arity, Self::MAX_RANK));
+        }
+        if !symbols.iter().any(|s| s.arity == 0) {
+            return Err(RewriteError::InvalidRule {
+                message: String::from("grounding domain needs at least one constant symbol"),
+            });
+        }
+        let mut sorted = symbols;
+        sorted.sort();
+        if sorted.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(RewriteError::InvalidRule {
+                message: String::from("grounding domain contains duplicate ranked symbols"),
+            });
+        }
+        if max_depth == 0 || max_depth > Self::MAX_DEPTH {
+            return Err(invalid("grounding depth", max_depth, Self::MAX_DEPTH));
+        }
+        if max_terms == 0 || max_terms > Self::MAX_TERMS {
+            return Err(invalid("grounding terms", max_terms, Self::MAX_TERMS));
+        }
+        Ok(Self {
+            symbols: sorted,
+            max_depth,
+            max_terms,
+        })
+    }
+
+    /// The validated ranked symbols, in canonical (name, arity) order.
+    pub fn symbols(&self) -> &[RankedSymbol] {
+        &self.symbols
+    }
+
+    /// Enumerate domain terms in canonical order: ascending node
+    /// count, then head-symbol (name, arity) order, then
+    /// lexicographic children. At most `max_terms` terms are emitted;
+    /// every generated candidate is accounted against `resources`.
+    ///
+    /// The sweep covers term sizes `1..=max_terms`. If the operation
+    /// budget is exhausted mid-sweep, enumeration stops and returns
+    /// the canonical prefix; callers detect truncation through
+    /// `resources.operations()` (grounding reports it as
+    /// [`GroundingOutcome::Partial`]).
+    pub fn enumerate(&self, resources: &mut RelationResources) -> RewriteResult<Vec<Term>> {
+        let mut out: Vec<Term> = Vec::new();
+        for size in 1..=self.max_terms {
+            if out.len() >= self.max_terms {
+                break;
+            }
+            for symbol in &self.symbols {
+                if out.len() >= self.max_terms {
+                    break;
+                }
+                match self.enumerate_headed(symbol, size, self.max_depth, resources, &mut out) {
+                    Ok(()) => {}
+                    Err(RewriteError::RelationLimitExceeded { .. }) => {
+                        return Ok(out);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Generate all terms of exactly `size` nodes with head `symbol`,
+    /// depth at most `depth_left`, in canonical child order.
+    fn enumerate_headed(
+        &self,
+        symbol: &RankedSymbol,
+        size: usize,
+        depth_left: usize,
+        resources: &mut RelationResources,
+        out: &mut Vec<Term>,
+    ) -> RewriteResult<()> {
+        resources.record_operations(1)?;
+        if symbol.arity == 0 {
+            if size == 1 {
+                resources.record_term(1, 1)?;
+                if out.len() < self.max_terms {
+                    out.push(Term::constant(symbol.name.clone()));
+                }
+            }
+            return Ok(());
+        }
+        if depth_left < 2 || size < symbol.arity + 1 {
+            return Ok(());
+        }
+        let mut child_sizes = vec![1usize; symbol.arity];
+        self.enumerate_compositions(
+            symbol,
+            size,
+            depth_left,
+            resources,
+            out,
+            &mut child_sizes,
+            0,
+        )
+    }
+
+    /// Lexicographic compositions of `size - 1` nodes into
+    /// `symbol.arity` child sizes, each at least 1.
+    #[allow(clippy::too_many_arguments)]
+    fn enumerate_compositions(
+        &self,
+        symbol: &RankedSymbol,
+        size: usize,
+        depth_left: usize,
+        resources: &mut RelationResources,
+        out: &mut Vec<Term>,
+        child_sizes: &mut Vec<usize>,
+        position: usize,
+    ) -> RewriteResult<()> {
+        if out.len() >= self.max_terms {
+            return Ok(());
+        }
+        if position + 1 == symbol.arity {
+            let used: usize = child_sizes[..position].iter().sum();
+            let remaining = size - 1;
+            if used >= remaining {
+                return Ok(());
+            }
+            child_sizes[position] = remaining - used;
+            return self.enumerate_product(symbol, child_sizes, depth_left, resources, out);
+        }
+        let remaining_positions = symbol.arity - position - 1;
+        let used: usize = child_sizes[..position].iter().sum();
+        let max_here = size - 1 - used - remaining_positions;
+        for child_size in 1..=max_here {
+            if out.len() >= self.max_terms {
+                return Ok(());
+            }
+            child_sizes[position] = child_size;
+            self.enumerate_compositions(
+                symbol,
+                size,
+                depth_left,
+                resources,
+                out,
+                child_sizes,
+                position + 1,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Lexicographic product of per-child enumerations for a fixed
+    /// child-size composition.
+    fn enumerate_product(
+        &self,
+        symbol: &RankedSymbol,
+        child_sizes: &[usize],
+        depth_left: usize,
+        resources: &mut RelationResources,
+        out: &mut Vec<Term>,
+    ) -> RewriteResult<()> {
+        let mut per_child: Vec<Vec<Term>> = Vec::with_capacity(child_sizes.len());
+        for child_size in child_sizes {
+            let mut child_terms = Vec::new();
+            for child_symbol in &self.symbols {
+                self.enumerate_headed(
+                    child_symbol,
+                    *child_size,
+                    depth_left - 1,
+                    resources,
+                    &mut child_terms,
+                )?;
+            }
+            if child_terms.is_empty() {
+                return Ok(());
+            }
+            per_child.push(child_terms);
+        }
+        let mut indices = vec![0usize; per_child.len()];
+        loop {
+            if out.len() >= self.max_terms {
+                return Ok(());
+            }
+            let args: Vec<Term> = per_child
+                .iter()
+                .zip(indices.iter())
+                .map(|(terms, index)| terms[*index].clone())
+                .collect();
+            let nodes = 1 + child_sizes.iter().sum::<usize>();
+            resources.record_term(nodes, self.max_depth)?;
+            out.push(Term::sym(symbol.name.clone(), args));
+            // Odometer increment, rightmost fastest: lexicographic.
+            let mut position = indices.len();
+            loop {
+                if position == 0 {
+                    return Ok(());
+                }
+                position -= 1;
+                indices[position] += 1;
+                if indices[position] < per_child[position].len() {
+                    break;
+                }
+                indices[position] = 0;
+            }
+        }
+    }
+}
+
+/// One replay-validated grounded predecessor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct GroundedPredecessor {
+    /// The existential assignment (freshened variable → domain term).
+    pub substitution: Substitution,
+    /// The fully grounded predecessor term.
+    pub term: Term,
+}
+
+/// Typed grounding result: `Complete` only when the canonical
+/// enumeration finished without truncation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum GroundingOutcome {
+    /// Every canonical assignment within the domain was validated.
+    Complete {
+        /// Replay-validated grounded predecessors, in canonical order.
+        grounded: Vec<GroundedPredecessor>,
+    },
+    /// A budget stopped enumeration; `grounded` is a strict canonical
+    /// prefix and never claims exhaustiveness.
+    Partial {
+        /// Replay-validated grounded predecessors emitted so far.
+        grounded: Vec<GroundedPredecessor>,
+    },
+}
+
+/// Ground a symbolic predecessor's existentials over a finite domain.
+///
+/// Assignments enumerate in canonical order; every candidate is
+/// validated against the predecessor's constraints and by forward
+/// replay (the grounded predecessor must rewrite to the grounded
+/// target through the original system) before emission. Duplicate
+/// grounded terms are suppressed. Budget exhaustion yields
+/// [`GroundingOutcome::Partial`], never an exhaustiveness claim.
+pub fn ground_predecessor(
+    system: &TermSystem,
+    target: &Term,
+    predecessor: &SymbolicPredecessor,
+    domain: &GroundingDomain,
+    limits: &RelationLimits,
+) -> RewriteResult<GroundingOutcome> {
+    let mut resources = RelationResources::new(limits);
+    let terms = domain.enumerate(&mut resources)?;
+    let mut partial = resources.operations() >= limits.max_operations();
+
+    let mut names: Vec<String> = predecessor
+        .existentials
+        .iter()
+        .map(|var| var.to_string())
+        .collect();
+    names.sort();
+    names.dedup();
+
+    let mut grounded: Vec<GroundedPredecessor> = Vec::new();
+    let mut seen: BTreeSet<Term> = BTreeSet::new();
+
+    // Canonical assignment product over the existential names. No
+    // existentials means exactly one (identity) candidate.
+    if names.is_empty() {
+        try_assignment(
+            system,
+            target,
+            predecessor,
+            &Substitution::new(),
+            &mut grounded,
+            &mut seen,
+        )?;
+    } else if terms.is_empty() {
+        partial = true;
+    } else {
+        let mut indices = vec![0usize; names.len()];
+        'assignments: loop {
+            if resources.operations() >= limits.max_operations() {
+                partial = true;
+                break;
+            }
+            resources.record_operations(1)?;
+            let mut assignment = Substitution::new();
+            for (name, index) in names.iter().zip(indices.iter()) {
+                assignment.insert(Variable::new(name.clone()), terms[*index].clone());
+            }
+            match try_assignment(
+                system,
+                target,
+                predecessor,
+                &assignment,
+                &mut grounded,
+                &mut seen,
+            ) {
+                Ok(()) => {}
+                Err(RewriteError::RelationLimitExceeded { .. }) => {
+                    partial = true;
+                    break;
+                }
+                Err(error) => return Err(error),
+            }
+            // Odometer increment, rightmost fastest: canonical product.
+            let mut position = names.len();
+            loop {
+                if position == 0 {
+                    break 'assignments;
+                }
+                position -= 1;
+                indices[position] += 1;
+                if indices[position] < terms.len() {
+                    break;
+                }
+                indices[position] = 0;
+            }
+        }
+    }
+
+    if partial {
+        Ok(GroundingOutcome::Partial { grounded })
+    } else {
+        Ok(GroundingOutcome::Complete { grounded })
+    }
+}
+
+/// Validate one assignment by constraints and forward replay; emit on
+/// success, suppress duplicates.
+fn try_assignment(
+    system: &TermSystem,
+    target: &Term,
+    predecessor: &SymbolicPredecessor,
+    assignment: &Substitution,
+    grounded: &mut Vec<GroundedPredecessor>,
+    seen: &mut BTreeSet<Term>,
+) -> RewriteResult<()> {
+    let constraints_ok = predecessor
+        .constraints
+        .constraints()
+        .iter()
+        .all(|c| match c {
+            TermConstraint::Equal(left, right) => assignment.apply(left) == assignment.apply(right),
+            TermConstraint::NotEqual(left, right) => {
+                assignment.apply(left) != assignment.apply(right)
+            }
+        });
+    if !constraints_ok {
+        return Ok(());
+    }
+    let grounded_term = assignment.apply(&predecessor.term);
+    let grounded_target = assignment.apply(&predecessor.substitution.apply(target));
+    let replays = system
+        .successors(&grounded_term)?
+        .contains(&grounded_target);
+    if replays && seen.insert(grounded_term.clone()) {
+        grounded.push(GroundedPredecessor {
+            substitution: assignment.clone(),
+            term: grounded_term,
+        });
+    }
+    Ok(())
+}

--- a/amari-rewrite/src/relation/mod.rs
+++ b/amari-rewrite/src/relation/mod.rs
@@ -13,11 +13,15 @@
 mod clause;
 mod constraints;
 pub(crate) mod digest;
+mod ground;
 mod limits;
 mod variable;
 
 pub use clause::{BackwardClause, RuleId};
 pub use constraints::{ConstraintOutcome, ConstraintSet, TermConstraint};
 pub use digest::Sha256Digest;
+pub use ground::{
+    ground_predecessor, GroundedPredecessor, GroundingDomain, GroundingOutcome, RankedSymbol,
+};
 pub use limits::{RelationLimits, RelationResources};
 pub use variable::{LogicVar, LogicVarNamespace};

--- a/amari-rewrite/tests/relation_grounding.rs
+++ b/amari-rewrite/tests/relation_grounding.rs
@@ -1,0 +1,297 @@
+//! Finite grounding domain contract tests (0.25 Cohort 2, Task 9).
+//!
+//! `GroundingDomain` is a caller-supplied finite ranked symbol domain
+//! with depth/count ceilings. Grounding enumerates existential
+//! assignments in canonical size/lexicographic order and validates
+//! constraints and forward replay before emitting terms. Empty or
+//! oversized domains fail before allocation.
+
+use amari_rewrite::inverse::{symbolic_predecessors, SymbolicPredecessor};
+use amari_rewrite::relation::{
+    ConstraintSet, GroundingDomain, GroundingOutcome, RankedSymbol, RelationLimits, Sha256Digest,
+    TermConstraint,
+};
+use amari_rewrite::trs::{Rule, Substitution, Term, TermSystem};
+use amari_rewrite::RewriteError;
+
+fn domain(
+    symbols: &[(&str, usize)],
+    max_depth: usize,
+    max_terms: usize,
+) -> amari_rewrite::error::RewriteResult<GroundingDomain> {
+    let ranked = symbols
+        .iter()
+        .map(|(name, arity)| RankedSymbol::new(*name, *arity))
+        .collect();
+    GroundingDomain::new(ranked, max_depth, max_terms)
+}
+
+fn resources_limits() -> RelationLimits {
+    RelationLimits::default()
+}
+
+#[test]
+fn domain_validation_rejects_invalid_specifications() {
+    // Empty domain.
+    assert!(matches!(
+        domain(&[], 4, 16),
+        Err(RewriteError::InvalidLimit { .. }) | Err(RewriteError::InvalidRule { .. })
+    ));
+    // No constants: no finite term is constructible.
+    assert!(domain(&[("f", 1)], 4, 16).is_err());
+    // Rank above ceiling.
+    assert!(domain(&[("a", 0), ("f", 17)], 4, 16).is_err());
+    // Too many symbols.
+    let many: Vec<RankedSymbol> = (0..257)
+        .map(|i| RankedSymbol::new(format!("c{i}"), 0))
+        .collect();
+    assert!(GroundingDomain::new(many, 4, 16).is_err());
+    // Depth/terms above ceilings, or zero.
+    assert!(domain(&[("a", 0)], 17, 16).is_err());
+    assert!(domain(&[("a", 0)], 0, 16).is_err());
+    assert!(domain(&[("a", 0)], 4, 65_537).is_err());
+    assert!(domain(&[("a", 0)], 4, 0).is_err());
+    // Duplicate ranked symbols.
+    assert!(domain(&[("a", 0), ("a", 0)], 4, 16).is_err());
+    // Same name at different arity is a distinct ranked symbol.
+    assert!(domain(&[("a", 0), ("a", 1)], 4, 16).is_ok());
+}
+
+#[test]
+fn enumeration_is_canonical_size_then_lexicographic() {
+    let dom = domain(&[("b", 0), ("a", 0), ("f", 1)], 8, 8).unwrap();
+    let mut resources = amari_rewrite::relation::RelationResources::new(&resources_limits());
+    let terms = dom.enumerate(&mut resources).unwrap();
+    let rendered: Vec<String> = terms.iter().map(|t| format!("{t:?}")).collect();
+    // Size 1: constants in name order. Size 2: f of each constant.
+    // Size 3: f of each size-2 term. Total capped at 8.
+    let expected: Vec<String> = [
+        "a",
+        "b",
+        "f(a)",
+        "f(b)",
+        "f(f(a))",
+        "f(f(b))",
+        "f(f(f(a)))",
+        "f(f(f(b)))",
+    ]
+    .iter()
+    .map(|s| format!("{:?}", parse(s)))
+    .collect();
+    assert_eq!(rendered, expected);
+}
+
+#[test]
+fn enumeration_is_declaration_order_independent() {
+    let first = domain(&[("b", 0), ("a", 0), ("f", 1)], 4, 6).unwrap();
+    let second = domain(&[("f", 1), ("a", 0), ("b", 0)], 4, 6).unwrap();
+    let mut r1 = amari_rewrite::relation::RelationResources::new(&resources_limits());
+    let mut r2 = amari_rewrite::relation::RelationResources::new(&resources_limits());
+    assert_eq!(
+        first.enumerate(&mut r1).unwrap(),
+        second.enumerate(&mut r2).unwrap(),
+        "same symbol set enumerates identically regardless of order"
+    );
+}
+
+#[test]
+fn depth_and_term_ceilings_bound_enumeration() {
+    // Depth 2 with unary f: a, b, f(a), f(b) — f(f(a)) is depth 3.
+    let dom = domain(&[("a", 0), ("b", 0), ("f", 1)], 2, 64).unwrap();
+    let mut resources = amari_rewrite::relation::RelationResources::new(&resources_limits());
+    let terms = dom.enumerate(&mut resources).unwrap();
+    assert_eq!(terms.len(), 4);
+    assert!(terms.contains(&parse("f(a)")));
+    assert!(!terms.contains(&parse("f(f(a))")));
+
+    // Term count truncation.
+    let dom = domain(&[("a", 0), ("f", 1)], 16, 3).unwrap();
+    let mut resources = amari_rewrite::relation::RelationResources::new(&resources_limits());
+    assert_eq!(dom.enumerate(&mut resources).unwrap().len(), 3);
+}
+
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) || text.starts_with('?') {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+fn predecessor_system() -> (TermSystem, Term, SymbolicPredecessor) {
+    // f(X, Y) -> g(X): Y is erased forward, existential backward.
+    let sys = TermSystem::new(vec![Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap()]);
+    let target = parse("g(a)");
+    let pred = symbolic_predecessors(&sys, &target, &resources_limits(), 0)
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    (sys, target, pred)
+}
+
+#[test]
+fn grounding_assigns_existentials_and_replays_forward() {
+    let (sys, target, pred) = predecessor_system();
+    assert_eq!(pred.existentials.len(), 1);
+    let dom = domain(&[("b", 0), ("c", 0)], 4, 16).unwrap();
+    let outcome = amari_rewrite::relation::ground_predecessor(
+        &sys,
+        &target,
+        &pred,
+        &dom,
+        &resources_limits(),
+    )
+    .unwrap();
+    let GroundingOutcome::Complete { grounded } = outcome else {
+        panic!("expected complete grounding");
+    };
+    let terms: Vec<Term> = grounded.iter().map(|g| g.term.clone()).collect();
+    assert_eq!(terms, vec![parse("f(a, b)"), parse("f(a, c)")]);
+    // Every emitted grounding replays forward to the target.
+    for g in &grounded {
+        let successors = sys.successors(&g.term).unwrap();
+        assert!(successors.contains(&target));
+    }
+}
+
+#[test]
+fn grounding_validates_constraints_before_emission() {
+    let (sys, target, mut pred) = predecessor_system();
+    // Add a residual: the existential must differ from constant b.
+    let existential = pred.existentials[0].to_string();
+    let mut constraints = ConstraintSet::new();
+    constraints.insert(TermConstraint::NotEqual(
+        Term::var(existential),
+        Term::constant("b"),
+    ));
+    pred.constraints = constraints;
+    let dom = domain(&[("b", 0), ("c", 0)], 4, 16).unwrap();
+    let outcome = amari_rewrite::relation::ground_predecessor(
+        &sys,
+        &target,
+        &pred,
+        &dom,
+        &resources_limits(),
+    )
+    .unwrap();
+    let GroundingOutcome::Complete { grounded } = outcome else {
+        panic!("expected complete grounding");
+    };
+    let terms: Vec<Term> = grounded.iter().map(|g| g.term.clone()).collect();
+    assert_eq!(terms, vec![parse("f(a, c)")]);
+}
+
+#[test]
+fn grounding_filters_non_replaying_candidates() {
+    let (sys, target, mut pred) = predecessor_system();
+    // Tamper: the predecessor term no longer rewrites to the target.
+    pred.term = parse("f(d, E)");
+    let dom = domain(&[("b", 0), ("c", 0)], 4, 16).unwrap();
+    let outcome = amari_rewrite::relation::ground_predecessor(
+        &sys,
+        &target,
+        &pred,
+        &dom,
+        &resources_limits(),
+    )
+    .unwrap();
+    let GroundingOutcome::Complete { grounded } = outcome else {
+        panic!("expected complete grounding");
+    };
+    // Groundings exist but none replay: E is free and unassigned, so
+    // grounding it via the domain still never reaches g(a).
+    assert!(grounded.is_empty());
+}
+
+#[test]
+fn budget_exhaustion_yields_partial_not_error() {
+    let (sys, target, pred) = predecessor_system();
+    // Rich domain, tiny operation budget: outcome is Partial.
+    let dom = domain(&[("a", 0), ("b", 0), ("f", 1)], 6, 64).unwrap();
+    let tight = RelationLimits::new(4_096, 64, 4_096, 12).unwrap();
+    let outcome =
+        amari_rewrite::relation::ground_predecessor(&sys, &target, &pred, &dom, &tight).unwrap();
+    assert!(matches!(outcome, GroundingOutcome::Partial { .. }));
+}
+
+#[test]
+fn grounded_terms_are_unique() {
+    let (sys, target, pred) = predecessor_system();
+    let dom = domain(&[("b", 0), ("c", 0)], 4, 16).unwrap();
+    let outcome = amari_rewrite::relation::ground_predecessor(
+        &sys,
+        &target,
+        &pred,
+        &dom,
+        &resources_limits(),
+    )
+    .unwrap();
+    let GroundingOutcome::Complete { grounded } = outcome else {
+        panic!("expected complete grounding");
+    };
+    let unique: std::collections::BTreeSet<_> = grounded.iter().map(|g| g.term.clone()).collect();
+    assert_eq!(unique.len(), grounded.len());
+}
+
+#[test]
+fn grounding_identity_when_no_existentials() {
+    // h(X) -> k(X): nothing erased; the single grounding is the
+    // predecessor itself (its free variables come from the target).
+    let sys = TermSystem::new(vec![Rule::new(parse("h(X)"), parse("k(X)")).unwrap()]);
+    let target = parse("k(a)");
+    let pred = symbolic_predecessors(&sys, &target, &resources_limits(), 0)
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(pred.existentials.is_empty());
+    let dom = domain(&[("b", 0)], 2, 4).unwrap();
+    let outcome = amari_rewrite::relation::ground_predecessor(
+        &sys,
+        &target,
+        &pred,
+        &dom,
+        &resources_limits(),
+    )
+    .unwrap();
+    let GroundingOutcome::Complete { grounded } = outcome else {
+        panic!("expected complete grounding");
+    };
+    assert_eq!(grounded.len(), 1);
+    assert_eq!(grounded[0].term, parse("h(a)"));
+}
+
+#[cfg(feature = "serialize")]
+#[test]
+fn grounding_types_serde_roundtrip() {
+    let dom = domain(&[("a", 0), ("f", 1)], 4, 8).unwrap();
+    let json = serde_json::to_string(&dom).unwrap();
+    let back: GroundingDomain = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, dom);
+    let symbol = RankedSymbol::new("f", 1);
+    let json = serde_json::to_string(&symbol).unwrap();
+    assert_eq!(serde_json::from_str::<RankedSymbol>(&json).unwrap(), symbol);
+    let _ = Substitution::new();
+    let _ = Sha256Digest::from_bytes([0u8; 32]);
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 9: finite grounding domains

Per plan Task 9 and the design's "Grounding" section. Ceilings from the
design's resource-authority table: **256 symbols, rank 16, depth 16,
65,536 emitted terms**.

## `GroundingDomain` + `RankedSymbol`

- Validation **before allocation**: empty domains, domains without
  constants (no finite term is constructible), duplicate ranked
  symbols, zero/above-ceiling depth/terms → typed errors.
- Symbols sorted by (name, arity) at construction — declaration order
  never affects enumeration (tested property).

## Canonical enumeration

Ascending node count → head-symbol order → lexicographic children
(size compositions, then odometer product). Every generated candidate
and emitted term is accounted against `RelationResources`. Budget
exhaustion stops the sweep and returns the canonical prefix —
documented and detectable; never silent.

## `ground_predecessor`

Existential assignments in canonical product order; each candidate is
validated against the predecessor's **constraints** (`Equal`/`NotEqual`
under the assignment) **and by forward replay** through the original
`TermSystem` before emission; duplicates suppressed. Typed
`GroundingOutcome::{Complete, Partial}` — `Partial` carries a strict
canonical prefix and never claims exhaustiveness.

## Evidence

RED→GREEN; 10 contract tests covering the plan's RED list (validation
matrix, canonical order, declaration-order independence, ceilings,
constraint filtering, replay filtering, Partial on exhaustion,
duplicate suppression, identity grounding) + serde roundtrip. Matrix:
default/no-default 40, serialize 43 (five rewrite suites); 21/21
all-features; MSRV 1.89; clippy `-D warnings` ×2; rustdoc
`-D warnings`; fmt clean; catalog post-fmt (`4e6acc8d`, shard 20/20);
publish-order/workflow-crates PASS.

Next: Task 10 — automatic typed residuals (`RewriteResidual`,
`ReversibleStep`, residual replay with authority-hash verification).
