### PR TITLE
feat: replay rewrites with typed residuals (0.25 Cohort 2, Task 10)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "4e6acc8d1eb14f3ecbfea2d8c96d42628a656bd260e5d8aa73b36a7774620095",
+  "content_hash": "f0ba1f4e71b8da93e366699a25eee9991229927e99acf06e5bea9a148b6521bd",
   "crates": [
     {
       "name": "amari",
@@ -374201,6 +374201,18 @@
                 }
               },
               {
+                "name": "NoRule",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "rule_name",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "InvalidLimit",
                 "data": {
                   "kind": "struct",
@@ -374271,6 +374283,18 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "ResidualMismatch",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -374321,6 +374345,18 @@
                       "fields": [
                         {
                           "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "NoRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "rule_name",
                           "ty": "String"
                         }
                       ]
@@ -374388,6 +374424,18 @@
                   },
                   {
                     "name": "InvalidSubstitution",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ResidualMismatch",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -374889,6 +374937,18 @@
                 }
               },
               {
+                "name": "NoRule",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "rule_name",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "InvalidLimit",
                 "data": {
                   "kind": "struct",
@@ -374959,6 +375019,18 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "ResidualMismatch",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -375009,6 +375081,18 @@
                       "fields": [
                         {
                           "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "NoRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "rule_name",
                           "ty": "String"
                         }
                       ]
@@ -375076,6 +375160,18 @@
                   },
                   {
                     "name": "InvalidSubstitution",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ResidualMismatch",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -375817,6 +375913,18 @@
                 }
               },
               {
+                "name": "NoRule",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "rule_name",
+                      "ty": "String"
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "InvalidLimit",
                 "data": {
                   "kind": "struct",
@@ -375887,6 +375995,18 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "ResidualMismatch",
+                "data": {
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "name": "message",
+                      "ty": "String"
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -375937,6 +376057,18 @@
                       "fields": [
                         {
                           "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "NoRule",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "rule_name",
                           "ty": "String"
                         }
                       ]
@@ -376004,6 +376136,18 @@
                   },
                   {
                     "name": "InvalidSubstitution",
+                    "data": {
+                      "kind": "struct",
+                      "fields": [
+                        {
+                          "name": "message",
+                          "ty": "String"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ResidualMismatch",
                     "data": {
                       "kind": "struct",
                       "fields": [
@@ -378815,6 +378959,246 @@
           ]
         },
         {
+          "path": "amari_rewrite::reversible::ForwardTransition",
+          "kind": "struct",
+          "signature": "pub struct ForwardTransition",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "rule_id",
+                "ty": "RuleId"
+              },
+              {
+                "label": "position",
+                "ty": "Path"
+              },
+              {
+                "label": "from",
+                "ty": "Term"
+              },
+              {
+                "label": "to",
+                "ty": "Term"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::step",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct ForwardTransition",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "rule_id",
+                    "ty": "RuleId"
+                  },
+                  {
+                    "label": "position",
+                    "ty": "Path"
+                  },
+                  {
+                    "label": "from",
+                    "ty": "Term"
+                  },
+                  {
+                    "label": "to",
+                    "ty": "Term"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/reversible/step.rs",
+              "source_module": "amari_rewrite::reversible::step",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::step",
+              "declaration_ident": "ForwardTransition"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::ReversibleStep",
+          "kind": "struct",
+          "signature": "pub struct ReversibleStep",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "target",
+                "ty": "Term"
+              },
+              {
+                "label": "residual",
+                "ty": "RewriteResidual"
+              },
+              {
+                "label": "transition",
+                "ty": "ForwardTransition"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::step",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct ReversibleStep",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "target",
+                    "ty": "Term"
+                  },
+                  {
+                    "label": "residual",
+                    "ty": "RewriteResidual"
+                  },
+                  {
+                    "label": "transition",
+                    "ty": "ForwardTransition"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/reversible/step.rs",
+              "source_module": "amari_rewrite::reversible::step",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::step",
+              "declaration_ident": "ReversibleStep"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::ReversibleStep::apply",
+          "kind": "method",
+          "signature": "pub fn apply (system : & TermSystem , source : & Term , rule : & Rule , position : & Path , limits : & RelationLimits ,) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::step",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn apply (system : & TermSystem , source : & Term , rule : & Rule , position : & Path , limits : & RelationLimits ,) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/reversible/step.rs",
+              "source_module": "amari_rewrite::reversible::step",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::step",
+              "declaration_ident": "ReversibleStep::apply"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual",
+          "kind": "struct",
+          "signature": "pub struct RewriteResidual",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "rule_id",
+                "ty": "RuleId"
+              },
+              {
+                "label": "position",
+                "ty": "Path"
+              },
+              {
+                "label": "erased_bindings",
+                "ty": "Vec < (LogicVar , Term) >"
+              },
+              {
+                "label": "source_hash",
+                "ty": "Sha256Digest"
+              },
+              {
+                "label": "target_hash",
+                "ty": "Sha256Digest"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::residual",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RewriteResidual",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "rule_id",
+                    "ty": "RuleId"
+                  },
+                  {
+                    "label": "position",
+                    "ty": "Path"
+                  },
+                  {
+                    "label": "erased_bindings",
+                    "ty": "Vec < (LogicVar , Term) >"
+                  },
+                  {
+                    "label": "source_hash",
+                    "ty": "Sha256Digest"
+                  },
+                  {
+                    "label": "target_hash",
+                    "ty": "Sha256Digest"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/reversible/residual.rs",
+              "source_module": "amari_rewrite::reversible::residual",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::residual",
+              "declaration_ident": "RewriteResidual"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual::digest",
+          "kind": "method",
+          "signature": "pub fn digest (& self) -> Sha256Digest",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::residual",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn digest (& self) -> Sha256Digest",
+              "source_path": "amari-rewrite/src/reversible/residual.rs",
+              "source_module": "amari_rewrite::reversible::residual",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::residual",
+              "declaration_ident": "RewriteResidual::digest"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual::replay",
+          "kind": "method",
+          "signature": "pub fn replay (& self , system : & TermSystem , target : & Term , limits : & RelationLimits ,) -> RewriteResult < Term >",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::residual",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn replay (& self , system : & TermSystem , target : & Term , limits : & RelationLimits ,) -> RewriteResult < Term >",
+              "source_path": "amari-rewrite/src/reversible/residual.rs",
+              "source_module": "amari_rewrite::reversible::residual",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::residual",
+              "declaration_ident": "RewriteResidual::replay"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::rewritable::Path",
           "kind": "struct",
           "signature": "pub struct Path",
@@ -381025,6 +381409,60 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::ForwardTransition",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ForwardTransition"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::ReversibleStep",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ReversibleStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::RewriteResidual",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::residual",
+            "ident": "RewriteResidual"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::rewritable::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -381793,6 +382231,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::ForwardTransition",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ForwardTransition"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::ReversibleStep",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ReversibleStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::RewriteResidual",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::residual",
+            "ident": "RewriteResidual"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382694,6 +383186,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::ForwardTransition",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ForwardTransition"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::ReversibleStep",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ReversibleStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::RewriteResidual",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::residual",
+            "ident": "RewriteResidual"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -384012,6 +384558,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::ForwardTransition",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ForwardTransition"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::ReversibleStep",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::step",
+            "ident": "ReversibleStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::RewriteResidual",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::residual",
+            "ident": "RewriteResidual"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -386090,6 +386690,62 @@
           "surface_kind": "top_level"
         },
         {
+          "path": "amari_rewrite::reversible",
+          "source_path": "amari-rewrite/src/reversible/mod.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "module"
+        },
+        {
+          "path": "amari_rewrite::reversible::ForwardTransition",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::ReversibleStep",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::ReversibleStep::apply",
+          "source_path": "amari-rewrite/src/reversible/step.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual::digest",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::RewriteResidual::replay",
+          "source_path": "amari-rewrite/src/reversible/residual.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::rewritable",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -386711,6 +387367,7 @@
         "amari_rewrite::prelude",
         "amari_rewrite::prelude::anti_unify",
         "amari_rewrite::relation",
+        "amari_rewrite::reversible",
         "amari_rewrite::rewritable",
         "amari_rewrite::smt",
         "amari_rewrite::synthesis",

--- a/amari-rewrite/src/error.rs
+++ b/amari-rewrite/src/error.rs
@@ -19,6 +19,12 @@ pub enum RewriteError {
     /// A rewrite rule failed validation.
     #[error("invalid rule: {message}")]
     InvalidRule { message: String },
+    /// No rule applies at the requested position.
+    #[error("no rule applies: {rule_name}")]
+    NoRule {
+        /// The rule identity that failed to apply.
+        rule_name: String,
+    },
     /// A relation limit was zero or exceeded its fixed ceiling.
     #[error("invalid relation limit {resource}: {value} (ceiling {ceiling})")]
     InvalidLimit {
@@ -53,6 +59,14 @@ pub enum RewriteError {
     /// A substitution failed checked composition or validation.
     #[error("invalid substitution: {message}")]
     InvalidSubstitution {
+        /// Validation failure detail.
+        message: String,
+    },
+    /// A residual failed validation or its reconstructed source digest
+    /// did not match the recorded authority. Always a hard error: no
+    /// degraded or warning-only reconstruction is ever returned.
+    #[error("residual mismatch: {message}")]
+    ResidualMismatch {
         /// Validation failure detail.
         message: String,
     },

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod inverse;
 pub mod prelude;
 pub mod relation;
+pub mod reversible;
 pub mod rewritable;
 pub mod synthesis;
 pub mod trs;

--- a/amari-rewrite/src/reversible/mod.rs
+++ b/amari-rewrite/src/reversible/mod.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed residuals for exact backward replay (0.25 Cohort 2).
+//!
+//! A normal rewrite may erase information. Exact reversal uses a
+//! [`RewriteResidual`] produced during forward execution: rule
+//! identity, position, erased bindings (LHS variables absent from the
+//! RHS), and source/target authority hashes. Replay validates every
+//! field, reconstructs privately, compares the canonical source hash,
+//! and returns only on exact match.
+
+mod residual;
+mod step;
+
+pub use residual::RewriteResidual;
+pub use step::{ForwardTransition, ReversibleStep};

--- a/amari-rewrite/src/reversible/residual.rs
+++ b/amari-rewrite/src/reversible/residual.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The typed residual and its validating replay.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::relation::digest::encode_term;
+use crate::relation::{
+    BackwardClause, LogicVar, RelationLimits, RelationResources, RuleId, Sha256Digest,
+};
+use crate::rewritable::Path;
+use crate::trs::{match_pattern, Substitution, Term, TermSystem, Variable};
+
+/// Authority produced during a concrete forward step, sufficient for
+/// exact backward replay.
+///
+/// Binding keys are schema positions (`LogicVar::new(0, i)` over the
+/// rule's sorted erased-variable names), not query-freshened
+/// variables.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RewriteResidual {
+    /// Identity of the checked rule that fired.
+    pub rule_id: RuleId,
+    /// Position of the replaced subterm.
+    pub position: Path,
+    /// Bindings for variables the forward step erased.
+    pub erased_bindings: Vec<(LogicVar, Term)>,
+    /// Canonical digest of the source term.
+    pub source_hash: Sha256Digest,
+    /// Canonical digest of the target term.
+    pub target_hash: Sha256Digest,
+}
+
+fn mismatch(message: &str) -> RewriteError {
+    RewriteError::ResidualMismatch {
+        message: String::from(message),
+    }
+}
+
+impl RewriteResidual {
+    /// Deterministic authority digest of the residual itself.
+    pub fn digest(&self) -> Sha256Digest {
+        let mut encoding = Vec::new();
+        encoding.extend_from_slice(self.rule_id.digest().as_bytes());
+        let indices = self.position.as_slice();
+        encoding.extend_from_slice(&(indices.len() as u32).to_le_bytes());
+        for index in indices {
+            encoding.extend_from_slice(&(*index as u32).to_le_bytes());
+        }
+        encoding.extend_from_slice(&(self.erased_bindings.len() as u32).to_le_bytes());
+        for (key, term) in &self.erased_bindings {
+            encoding.extend_from_slice(&key.scope().to_le_bytes());
+            encoding.extend_from_slice(&key.index().to_le_bytes());
+            let mut variables = Vec::new();
+            encode_term(term, &mut variables, &mut encoding);
+        }
+        encoding.extend_from_slice(self.source_hash.as_bytes());
+        encoding.extend_from_slice(self.target_hash.as_bytes());
+        Sha256Digest::framed("amari.relation.residual/v1", &encoding)
+    }
+
+    /// Validating replay: reconstruct the source term from `target`.
+    ///
+    /// Validates (in order) target hash, rule identity, position,
+    /// binding schema, binding term limits, and RHS match; then
+    /// reconstructs privately and returns only when the canonical
+    /// source hash matches exactly. Any mismatch is a hard typed
+    /// [`RewriteError::ResidualMismatch`]; no degraded or partial
+    /// reconstruction is ever returned.
+    pub fn replay(
+        &self,
+        system: &TermSystem,
+        target: &Term,
+        limits: &RelationLimits,
+    ) -> RewriteResult<Term> {
+        let mut resources = RelationResources::new(limits);
+        resources.record_operations(1)?;
+
+        // Target authority.
+        let target_hash = Sha256Digest::canonical_term("amari.relation.term/v1", target);
+        if target_hash != self.target_hash {
+            return Err(mismatch("target hash does not match"));
+        }
+
+        // Rule identity.
+        let rule = system
+            .rules()
+            .iter()
+            .find(|rule| RuleId::from_rule(rule) == self.rule_id)
+            .ok_or_else(|| mismatch("rule identity not present in system"))?;
+
+        // Position validity.
+        let subterm = target
+            .subterm(&self.position)
+            .ok_or_else(|| mismatch("position is not valid in target"))?;
+
+        // Binding schema: count, key positions, uniqueness.
+        let clause = BackwardClause::compile(rule)?;
+        let erased = clause.erased_variables();
+        if self.erased_bindings.len() != erased.len() {
+            return Err(mismatch("binding schema length mismatch"));
+        }
+        for (index, (key, bound)) in self.erased_bindings.iter().enumerate() {
+            if *key != LogicVar::new(0, index as u32) {
+                return Err(mismatch("binding schema key mismatch"));
+            }
+            resources.record_term(term_nodes(bound), term_depth(bound))?;
+        }
+
+        // Recover RHS variables by matching the target subterm.
+        let recovered = match_pattern(rule.rhs(), subterm)
+            .ok_or_else(|| mismatch("rule RHS does not match target subterm"))?;
+
+        // Reconstruct privately: recovered RHS bindings ∪ erased.
+        let mut full = Substitution::new();
+        for (variable, term) in recovered.iter() {
+            full.insert(variable.clone(), term.clone());
+        }
+        for ((_, bound), name) in self.erased_bindings.iter().zip(erased.iter()) {
+            full.insert(Variable::new(name.clone()), bound.clone());
+        }
+        let source_subterm = full.apply(rule.lhs());
+        let reconstructed = target
+            .replace_at(&self.position, source_subterm)
+            .map_err(|_| mismatch("position replacement failed"))?;
+
+        // Exact authority comparison before returning anything.
+        let source_hash = Sha256Digest::canonical_term("amari.relation.term/v1", &reconstructed);
+        if source_hash != self.source_hash {
+            return Err(mismatch("reconstructed source hash mismatch"));
+        }
+        Ok(reconstructed)
+    }
+}
+
+fn term_nodes(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_nodes).sum::<usize>(),
+    }
+}
+
+fn term_depth(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_depth).max().unwrap_or(0),
+    }
+}

--- a/amari-rewrite/src/reversible/step.rs
+++ b/amari-rewrite/src/reversible/step.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Concrete forward steps carrying typed residual authority.
+
+use alloc::string::ToString;
+
+use crate::error::{RewriteError, RewriteResult};
+use crate::relation::{
+    BackwardClause, LogicVar, RelationLimits, RelationResources, RuleId, Sha256Digest,
+};
+use crate::reversible::RewriteResidual;
+use crate::rewritable::Path;
+use crate::trs::{match_pattern, Rule, Term, TermSystem, Variable};
+
+/// The local transition at one position: which rule fired and the
+/// subterm before/after.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct ForwardTransition {
+    /// Identity of the checked rule that fired.
+    pub rule_id: RuleId,
+    /// Position of the replaced subterm.
+    pub position: Path,
+    /// The matched subterm before the step.
+    pub from: Term,
+    /// The instantiated subterm after the step.
+    pub to: Term,
+}
+
+/// A concrete forward step together with the authority needed to
+/// reverse it exactly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReversibleStep {
+    /// The rewritten term.
+    pub target: Term,
+    /// Typed residual authority for exact backward replay.
+    pub residual: RewriteResidual,
+    /// The local transition performed.
+    pub transition: ForwardTransition,
+}
+
+impl ReversibleStep {
+    /// Apply `rule` at `position` in `source`, emitting residual
+    /// authority. Fails when the path is invalid or the rule's LHS
+    /// does not match there.
+    pub fn apply(
+        system: &TermSystem,
+        source: &Term,
+        rule: &Rule,
+        position: &Path,
+        limits: &RelationLimits,
+    ) -> RewriteResult<Self> {
+        let _ = system; // membership is validated at replay time.
+        let mut resources = RelationResources::new(limits);
+        resources.record_term(term_nodes(source), term_depth(source))?;
+        resources.record_operations(1)?;
+
+        let rule_id = RuleId::from_rule(rule);
+        let subterm = source.subterm(position).ok_or(RewriteError::InvalidPath)?;
+        let substitution = match_pattern(rule.lhs(), subterm).ok_or(RewriteError::NoRule {
+            rule_name: rule_id.to_string(),
+        })?;
+        let target_subterm = substitution.apply(rule.rhs());
+        let target = source.replace_at(position, target_subterm.clone())?;
+
+        // Erased bindings: LHS variables absent from the RHS, in
+        // sorted order, keyed by schema position.
+        let clause = BackwardClause::compile(rule)?;
+        let mut erased_bindings = alloc::vec::Vec::new();
+        for (index, name) in clause.erased_variables().iter().enumerate() {
+            let variable = Variable::new(name.clone());
+            let bound = substitution.get_var(&variable).cloned().ok_or(
+                RewriteError::InvalidSubstitution {
+                    message: alloc::string::String::from("match did not bind an erased variable"),
+                },
+            )?;
+            erased_bindings.push((LogicVar::new(0, index as u32), bound));
+        }
+
+        let source_hash = Sha256Digest::canonical_term("amari.relation.term/v1", source);
+        let target_hash = Sha256Digest::canonical_term("amari.relation.term/v1", &target);
+        Ok(Self {
+            target: target.clone(),
+            residual: RewriteResidual {
+                rule_id,
+                position: position.clone(),
+                erased_bindings,
+                source_hash,
+                target_hash,
+            },
+            transition: ForwardTransition {
+                rule_id,
+                position: position.clone(),
+                from: subterm.clone(),
+                to: target_subterm,
+            },
+        })
+    }
+}
+
+fn term_nodes(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_nodes).sum::<usize>(),
+    }
+}
+
+fn term_depth(term: &Term) -> usize {
+    match term {
+        Term::Var(_) => 1,
+        Term::Sym(_, args) => 1 + args.iter().map(term_depth).max().unwrap_or(0),
+    }
+}

--- a/amari-rewrite/tests/residual_roundtrip.rs
+++ b/amari-rewrite/tests/residual_roundtrip.rs
@@ -1,0 +1,335 @@
+//! Typed residual round-trip contract tests (0.25 Cohort 2, Task 10).
+//!
+//! A forward step emits authority: rule identity, position, erased
+//! bindings, and source/target hashes. Replay validates every field,
+//! reconstructs privately, compares the canonical source hash, and
+//! returns only on exact match — any tampering is a hard typed error
+//! with no returned reconstruction.
+
+use amari_rewrite::relation::{RelationLimits, Sha256Digest};
+use amari_rewrite::reversible::{ReversibleStep, RewriteResidual};
+use amari_rewrite::trs::{Rule, Term, TermSystem};
+use amari_rewrite::RewriteError;
+
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+fn limits() -> RelationLimits {
+    RelationLimits::default()
+}
+
+#[test]
+fn lossless_rule_roundtrips() {
+    let rule = Rule::new(parse("f(X)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("h(f(a))");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root().child(0),
+        &limits(),
+    )
+    .unwrap();
+    assert_eq!(step.target, parse("h(g(a))"));
+    // Nothing erased: no bindings.
+    assert!(step.residual.erased_bindings.is_empty());
+    let reconstructed = step.residual.replay(&sys, &step.target, &limits()).unwrap();
+    assert_eq!(reconstructed, source);
+}
+
+#[test]
+fn erased_variable_is_carried_by_the_residual() {
+    let rule = Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a, b)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+    assert_eq!(step.target, parse("g(a)"));
+    // Y ↦ b is exactly the erased binding.
+    assert_eq!(step.residual.erased_bindings.len(), 1);
+    assert_eq!(step.residual.erased_bindings[0].1, parse("b"));
+    let reconstructed = step.residual.replay(&sys, &step.target, &limits()).unwrap();
+    assert_eq!(reconstructed, source);
+}
+
+#[test]
+fn nested_position_roundtrips() {
+    let rule = Rule::new(parse("a"), parse("b")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("h(k(a), j(a))");
+    let path = amari_rewrite::rewritable::Path::root().child(1).child(0);
+    let step = ReversibleStep::apply(&sys, &source, &rule, &path, &limits()).unwrap();
+    assert_eq!(step.target, parse("h(k(a), j(b))"));
+    assert_eq!(step.residual.position.as_slice(), &[1, 0]);
+    let reconstructed = step.residual.replay(&sys, &step.target, &limits()).unwrap();
+    assert_eq!(reconstructed, source);
+}
+
+#[test]
+fn duplicate_rhs_variables_roundtrip() {
+    let rule = Rule::new(parse("f(X)"), parse("g(X, X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+    assert_eq!(step.target, parse("g(a, a)"));
+    let reconstructed = step.residual.replay(&sys, &step.target, &limits()).unwrap();
+    assert_eq!(reconstructed, source);
+}
+
+#[test]
+fn same_rhs_rules_are_disambiguated_by_rule_identity() {
+    let r1 = Rule::new(parse("p(X)"), parse("q(X)")).unwrap();
+    let r2 = Rule::new(parse("s(X, Y)"), parse("q(X)")).unwrap();
+    let sys = TermSystem::new(vec![r1.clone(), r2.clone()]);
+    let source = parse("s(a, b)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &r2,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+    // Replay with the honest residual works.
+    let reconstructed = step.residual.replay(&sys, &step.target, &limits()).unwrap();
+    assert_eq!(reconstructed, source);
+    // Tampered identity: claim the residual came from r1.
+    let mut forged = step.residual.clone();
+    forged.rule_id = amari_rewrite::relation::RuleId::from_rule(&r1);
+    assert!(matches!(
+        forged.replay(&sys, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+}
+
+#[test]
+fn tampering_is_a_hard_error_with_no_reconstruction() {
+    let rule = Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a, b)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+
+    // Tampered path.
+    let mut bad = step.residual.clone();
+    bad.position = amari_rewrite::rewritable::Path::root().child(0);
+    assert!(bad.replay(&sys, &step.target, &limits()).is_err());
+
+    // Tampered binding value.
+    let mut bad = step.residual.clone();
+    bad.erased_bindings[0].1 = parse("c");
+    assert!(matches!(
+        bad.replay(&sys, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+
+    // Tampered binding schema (extra binding).
+    let mut bad = step.residual.clone();
+    bad.erased_bindings
+        .push((amari_rewrite::relation::LogicVar::new(0, 99), parse("c")));
+    assert!(matches!(
+        bad.replay(&sys, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+
+    // Tampered source hash.
+    let mut bad = step.residual.clone();
+    bad.source_hash = Sha256Digest::from_bytes([0u8; 32]);
+    assert!(matches!(
+        bad.replay(&sys, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+
+    // Tampered target hash.
+    let mut bad = step.residual.clone();
+    bad.target_hash = Sha256Digest::from_bytes([0u8; 32]);
+    assert!(matches!(
+        bad.replay(&sys, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+
+    // Replay against a different target term fails.
+    assert!(step
+        .residual
+        .replay(&sys, &parse("g(c)"), &limits())
+        .is_err());
+
+    // Replay against a system missing the rule fails.
+    let other = TermSystem::new(vec![]);
+    assert!(step
+        .residual
+        .replay(&other, &step.target, &limits())
+        .is_err());
+}
+
+#[test]
+fn residual_bytes_are_deterministic() {
+    let rule = Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a, b)");
+    let make = || {
+        ReversibleStep::apply(
+            &sys,
+            &source,
+            &rule,
+            &amari_rewrite::rewritable::Path::root(),
+            &limits(),
+        )
+        .unwrap()
+        .residual
+    };
+    assert_eq!(make().digest(), make().digest());
+    // Different residuals have different digests.
+    let other_rule = Rule::new(parse("f(X, Y)"), parse("h(X)")).unwrap();
+    let other_sys = TermSystem::new(vec![other_rule.clone()]);
+    let other = ReversibleStep::apply(
+        &other_sys,
+        &source,
+        &other_rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap()
+    .residual;
+    assert_ne!(make().digest(), other.digest());
+}
+
+#[test]
+fn residual_limits_are_enforced() {
+    let rule = Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a, b)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+    // A residual whose binding exceeds the caller's term limits is
+    // rejected before reconstruction.
+    let tight = RelationLimits::new(1, 64, 4_096, 1_000_000).unwrap();
+    let mut oversized = step.residual.clone();
+    oversized.erased_bindings[0].1 = parse("k(a)");
+    oversized.source_hash = Sha256Digest::from_bytes([7u8; 32]);
+    assert!(matches!(
+        oversized.replay(&sys, &step.target, &tight),
+        Err(RewriteError::RelationLimitExceeded { .. })
+            | Err(RewriteError::ResidualMismatch { .. })
+    ));
+}
+
+#[test]
+fn roundtrip_property_over_small_systems() {
+    // backward(forward(source)) == source across generated checked
+    // systems, positions, and sources.
+    let systems: Vec<Vec<(&str, &str)>> = vec![
+        vec![("f(X)", "g(X)")],
+        vec![("f(X, Y)", "X")],
+        vec![
+            ("add(X, zero)", "X"),
+            ("add(X, succ(Y))", "succ(add(X, Y))"),
+        ],
+        vec![("a", "b"), ("h(X)", "k(X, X)")],
+    ];
+    let sources = [
+        "f(a)",
+        "f(a, b)",
+        "h(f(a))",
+        "add(succ(zero), succ(zero))",
+        "h(a)",
+        "k(a, a)",
+        "j(h(a), f(b, c))",
+    ];
+    for rules in &systems {
+        let parsed_rules: Vec<Rule> = rules
+            .iter()
+            .map(|(l, r)| Rule::new(parse(l), parse(r)).unwrap())
+            .collect();
+        let sys = TermSystem::new(parsed_rules);
+        for source_text in &sources {
+            let source = parse(source_text);
+            for rule in sys.rules() {
+                for path in source.positions() {
+                    if let Ok(step) = ReversibleStep::apply(&sys, &source, rule, &path, &limits()) {
+                        let reconstructed =
+                            step.residual.replay(&sys, &step.target, &limits()).unwrap();
+                        assert_eq!(
+                            reconstructed, source,
+                            "round trip failed for {source_text} via \
+                             {rule:?} at {path:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "serialize")]
+#[test]
+fn residual_serde_roundtrip() {
+    let rule = Rule::new(parse("f(X, Y)"), parse("g(X)")).unwrap();
+    let sys = TermSystem::new(vec![rule.clone()]);
+    let source = parse("f(a, b)");
+    let step = ReversibleStep::apply(
+        &sys,
+        &source,
+        &rule,
+        &amari_rewrite::rewritable::Path::root(),
+        &limits(),
+    )
+    .unwrap();
+    let json = serde_json::to_string(&step.residual).unwrap();
+    let back: RewriteResidual = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, step.residual);
+    let json = serde_json::to_string(&step).unwrap();
+    let back: ReversibleStep = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, step);
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 10: automatic typed residuals

Per plan Task 10 and the design's "Reversible steps and typed
residuals" section.

## `reversible` module

- **`RewriteResidual`** — exactly the design struct: `rule_id`,
  `position`, `erased_bindings`, `source_hash`, `target_hash`. Erased
  bindings derive from LHS variables absent from the RHS (sorted,
  keyed by schema position); `digest()` is a framed canonical encoding
  — deterministic, tamper-evident bytes.
- **`ReversibleStep::apply`** — concrete forward step emitting target
  + residual + `ForwardTransition`. Non-match → new typed `NoRule`
  error (design error list); invalid path → `InvalidPath`.
- **`RewriteResidual::replay`** — validates in order: target hash →
  rule identity (disambiguates same-RHS rules) → position → binding
  schema → binding term limits → RHS match; then reconstructs
  *privately* and returns **only** on exact canonical source-hash
  match. Any mismatch = hard typed `ResidualMismatch`. No degraded or
  warning-only reconstruction ever leaves the function.

## Evidence

RED→GREEN; 9 contract tests + property sweep: lossless/erased/nested/
duplicate-RHS round trips, same-RHS disambiguation, a seven-case
tamper matrix (path, binding value, binding schema, source hash,
target hash, wrong target, missing rule — all hard errors),
deterministic digests, term limits, and
`backward(forward(source)) == source` over 4 checked systems × 7
sources × all positions. Serde roundtrips. Matrix: 49
default/no-default, 53 serialize, 22/22 all-features; MSRV 1.89;
clippy `-D warnings` ×2; rustdoc `-D warnings`; catalog post-fmt
(`f0ba1f4e`, shard 20/20); verifiers PASS.

Next: Task 11 — bidirectional systems + inverse analysis
(`BidirectionalRule`/`BidirectionalSystem`, reversibility reports).
