### PR TITLE
feat: analyze bidirectional rewrite systems (0.25 Cohort 2, Task 11)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "f0ba1f4e71b8da93e366699a25eee9991229927e99acf06e5bea9a148b6521bd",
+  "content_hash": "83ccd175ab7e5cfe6e547084113cf5c9853c5b167f0473b42e0fe5f29a6c2665",
   "crates": [
     {
       "name": "amari",
@@ -374476,6 +374476,337 @@
           ]
         },
         {
+          "path": "amari_rewrite::analysis::BackwardKind",
+          "kind": "enum",
+          "signature": "pub enum BackwardKind",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Lossless",
+                "data": {
+                  "kind": "unit"
+                }
+              },
+              {
+                "name": "Existential",
+                "data": {
+                  "kind": "unit"
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum BackwardKind",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Lossless",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  },
+                  {
+                    "name": "Existential",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "BackwardKind"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::BranchingEstimate",
+          "kind": "struct",
+          "signature": "pub struct BranchingEstimate",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "existentials",
+                "ty": "usize"
+              },
+              {
+                "label": "ambiguous_peers",
+                "ty": "usize"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BranchingEstimate",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "existentials",
+                    "ty": "usize"
+                  },
+                  {
+                    "label": "ambiguous_peers",
+                    "ty": "usize"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "BranchingEstimate"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseAnalyzer",
+          "kind": "struct",
+          "signature": "pub struct InverseAnalyzer",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct InverseAnalyzer",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "InverseAnalyzer"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseAnalyzer::analyze",
+          "kind": "method",
+          "signature": "pub fn analyze (system : & BidirectionalSystem) -> InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn analyze (system : & BidirectionalSystem) -> InverseReport",
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "InverseAnalyzer::analyze"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseReport",
+          "kind": "struct",
+          "signature": "pub struct InverseReport",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "rules",
+                "ty": "Vec < RuleAnalysis >"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct InverseReport",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "rules",
+                    "ty": "Vec < RuleAnalysis >"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "InverseReport"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::ReversibilityClass",
+          "kind": "enum",
+          "signature": "pub enum ReversibilityClass",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Reversible",
+                "data": {
+                  "kind": "unit"
+                }
+              },
+              {
+                "name": "Ambiguous",
+                "data": {
+                  "kind": "unit"
+                }
+              },
+              {
+                "name": "LossyResidual",
+                "data": {
+                  "kind": "unit"
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum ReversibilityClass",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Reversible",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  },
+                  {
+                    "name": "Ambiguous",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  },
+                  {
+                    "name": "LossyResidual",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "ReversibilityClass"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::analysis::RuleAnalysis",
+          "kind": "struct",
+          "signature": "pub struct RuleAnalysis",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "rule_id",
+                "ty": "RuleId"
+              },
+              {
+                "label": "erased_variables",
+                "ty": "Vec < String >"
+              },
+              {
+                "label": "backward",
+                "ty": "BackwardKind"
+              },
+              {
+                "label": "rhs_ambiguity",
+                "ty": "Vec < RuleId >"
+              },
+              {
+                "label": "reversibility",
+                "ty": "ReversibilityClass"
+              },
+              {
+                "label": "branching",
+                "ty": "BranchingEstimate"
+              },
+              {
+                "label": "unsupported_reasons",
+                "ty": "Vec < String >"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::analysis::inverse",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct RuleAnalysis",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "rule_id",
+                    "ty": "RuleId"
+                  },
+                  {
+                    "label": "erased_variables",
+                    "ty": "Vec < String >"
+                  },
+                  {
+                    "label": "backward",
+                    "ty": "BackwardKind"
+                  },
+                  {
+                    "label": "rhs_ambiguity",
+                    "ty": "Vec < RuleId >"
+                  },
+                  {
+                    "label": "reversibility",
+                    "ty": "ReversibilityClass"
+                  },
+                  {
+                    "label": "branching",
+                    "ty": "BranchingEstimate"
+                  },
+                  {
+                    "label": "unsupported_reasons",
+                    "ty": "Vec < String >"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/analysis/inverse.rs",
+              "source_module": "amari_rewrite::analysis::inverse",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::analysis::inverse",
+              "declaration_ident": "RuleAnalysis"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::analysis::unify",
           "kind": "fn",
           "signature": "pub fn unify (left : & Term , right : & Term , resources : & mut RelationResources ,) -> RewriteResult < Substitution >",
@@ -378959,6 +379290,322 @@
           ]
         },
         {
+          "path": "amari_rewrite::reversible::BidirectionalRule",
+          "kind": "struct",
+          "signature": "pub struct BidirectionalRule",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BidirectionalRule",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalRule"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::clause",
+          "kind": "method",
+          "signature": "pub fn clause (& self) -> & BackwardClause",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn clause (& self) -> & BackwardClause",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalRule::clause"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::compile",
+          "kind": "method",
+          "signature": "pub fn compile (rule : Rule) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn compile (rule : Rule) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalRule::compile"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::forward",
+          "kind": "method",
+          "signature": "pub fn forward (& self) -> & Rule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn forward (& self) -> & Rule",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalRule::forward"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::rule_id",
+          "kind": "method",
+          "signature": "pub fn rule_id (& self) -> RuleId",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn rule_id (& self) -> RuleId",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalRule::rule_id"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalStep",
+          "kind": "struct",
+          "signature": "pub struct BidirectionalStep",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "target",
+                "ty": "Term"
+              },
+              {
+                "label": "transition",
+                "ty": "ForwardTransition"
+              },
+              {
+                "label": "residual",
+                "ty": "Option < RewriteResidual >"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BidirectionalStep",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "target",
+                    "ty": "Term"
+                  },
+                  {
+                    "label": "transition",
+                    "ty": "ForwardTransition"
+                  },
+                  {
+                    "label": "residual",
+                    "ty": "Option < RewriteResidual >"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalStep"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem",
+          "kind": "struct",
+          "signature": "pub struct BidirectionalSystem",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BidirectionalSystem",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::forward_step",
+          "kind": "method",
+          "signature": "pub fn forward_step (& self , source : & Term , rule_id : & RuleId , position : & Path , residual : bool , limits : & RelationLimits ,) -> RewriteResult < BidirectionalStep >",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn forward_step (& self , source : & Term , rule_id : & RuleId , position : & Path , residual : bool , limits : & RelationLimits ,) -> RewriteResult < BidirectionalStep >",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::forward_step"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::forward_system",
+          "kind": "method",
+          "signature": "pub fn forward_system (& self) -> & TermSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn forward_system (& self) -> & TermSystem",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::forward_system"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::new",
+          "kind": "method",
+          "signature": "pub fn new (rules : Vec < Rule >) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (rules : Vec < Rule >) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::predecessors",
+          "kind": "method",
+          "signature": "pub fn predecessors (& self , target : & Term , limits : & RelationLimits , scope : u32 ,) -> RewriteResult < Vec < SymbolicPredecessor > >",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn predecessors (& self , target : & Term , limits : & RelationLimits , scope : u32 ,) -> RewriteResult < Vec < SymbolicPredecessor > >",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::predecessors"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::replay",
+          "kind": "method",
+          "signature": "pub fn replay (& self , residual : & RewriteResidual , target : & Term , limits : & RelationLimits ,) -> RewriteResult < Term >",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn replay (& self , residual : & RewriteResidual , target : & Term , limits : & RelationLimits ,) -> RewriteResult < Term >",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::replay"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::reversibility",
+          "kind": "method",
+          "signature": "pub fn reversibility (& self) -> InverseReport",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn reversibility (& self) -> InverseReport",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::reversibility"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::rules",
+          "kind": "method",
+          "signature": "pub fn rules (& self) -> & [BidirectionalRule]",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::reversible::system",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn rules (& self) -> & [BidirectionalRule]",
+              "source_path": "amari-rewrite/src/reversible/system.rs",
+              "source_module": "amari_rewrite::reversible::system",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::reversible::system",
+              "declaration_ident": "BidirectionalSystem::rules"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::reversible::ForwardTransition",
           "kind": "struct",
           "signature": "pub struct ForwardTransition",
@@ -380904,6 +381551,96 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::analysis::InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "InverseReport"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::analysis::RuleAnalysis",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "RuleAnalysis"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::ars::RewriteStep",
           "source_path": "amari-rewrite/src/ars/mod.rs",
           "source_ordinal": 4,
@@ -381402,6 +382139,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalRule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalRule"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalStep",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalSystem"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -381607,6 +382398,60 @@
         },
         {
           "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
           "impl_type_path": "amari_rewrite::ars::Strategy",
           "source_path": "amari-rewrite/src/ars/mod.rs",
           "source_ordinal": 3,
@@ -381762,6 +382607,96 @@
             "kind": "local",
             "module": "amari_rewrite::error",
             "ident": "RewriteError"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::analysis::InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "InverseReport"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::analysis::RuleAnalysis",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "RuleAnalysis"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382231,6 +383166,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalRule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalRule"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalStep",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalSystem"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382706,6 +383695,96 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::analysis::InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "InverseReport"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::analysis::RuleAnalysis",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "RuleAnalysis"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::ars::RewriteStep",
           "source_path": "amari-rewrite/src/ars/mod.rs",
           "source_ordinal": 4,
@@ -383186,6 +384265,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalRule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalRule"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalStep",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalSystem"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -383621,6 +384754,60 @@
             "kind": "local",
             "module": "amari_rewrite::rewritable",
             "ident": "Path"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -384078,6 +385265,96 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BackwardKind"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "BranchingEstimate"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::analysis::InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "InverseReport"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "ReversibilityClass"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::analysis::RuleAnalysis",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::analysis::inverse",
+            "ident": "RuleAnalysis"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::ars::RewriteStep",
           "source_path": "amari-rewrite/src/ars/mod.rs",
           "source_ordinal": 4,
@@ -384558,6 +385835,60 @@
             "kind": "local",
             "module": "amari_rewrite::relation::constraints",
             "ident": "TermConstraint"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalRule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalRule"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalStep",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalStep"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::reversible::BidirectionalSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::reversible::system",
+            "ident": "BidirectionalSystem"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -385272,6 +386603,62 @@
           "gate": "always",
           "status": "enabled",
           "surface_kind": "module"
+        },
+        {
+          "path": "amari_rewrite::analysis::BackwardKind",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::BranchingEstimate",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseAnalyzer",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseAnalyzer::analyze",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::analysis::InverseReport",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::ReversibilityClass",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::analysis::RuleAnalysis",
+          "source_path": "amari-rewrite/src/analysis/inverse.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
         },
         {
           "path": "amari_rewrite::analysis::unify",
@@ -386696,6 +388083,118 @@
           "gate": "always",
           "status": "enabled",
           "surface_kind": "module"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::clause",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::compile",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::forward",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalRule::rule_id",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalStep",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::forward_step",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::forward_system",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::new",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::predecessors",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::replay",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::reversibility",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::reversible::BidirectionalSystem::rules",
+          "source_path": "amari-rewrite/src/reversible/system.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
         },
         {
           "path": "amari_rewrite::reversible::ForwardTransition",

--- a/amari-rewrite/src/analysis/inverse.rs
+++ b/amari-rewrite/src/analysis/inverse.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Structural inverse analysis over bidirectional systems.
+//!
+//! [`InverseAnalyzer`] reports per-rule evidence: erased variables and
+//! required residual schema, RHS overlap/ambiguity classes, lossless
+//! versus existential backward behavior, deterministic branching
+//! estimates, and reversibility classifiers. Classification is
+//! conservative: a rule is `Reversible` only when it is structurally
+//! lossless AND its RHS unifies with no other rule's RHS — the report
+//! never claims a functional inverse without that evidence.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::analysis::unify::unify;
+use crate::relation::{RelationLimits, RelationResources, RuleId};
+use crate::reversible::BidirectionalSystem;
+
+/// Structural backward behavior of one rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum BackwardKind {
+    /// No variable is erased: every forward match is recoverable from
+    /// the target alone.
+    Lossless,
+    /// The forward step erases variables: backward reconstruction is
+    /// existential over the residual schema or a grounding domain.
+    Existential,
+}
+
+/// Conservative reversibility classifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum ReversibilityClass {
+    /// Lossless AND unambiguous: residual-free backward reconstruction
+    /// is unique.
+    Reversible,
+    /// Lossless in bindings but ambiguous: the RHS overlaps another
+    /// rule's RHS, so backward rule choice is not unique.
+    Ambiguous,
+    /// Information-losing: exact reversal requires residual authority
+    /// or grounding over the erased variables.
+    LossyResidual,
+}
+
+/// Structural branching estimate for backward exploration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BranchingEstimate {
+    /// Existential choices introduced by erased variables; over a
+    /// finite grounding domain of size `d`, each existential
+    /// multiplies the branching by `d`.
+    pub existentials: usize,
+    /// Other rules whose RHS unifies with this rule's RHS.
+    pub ambiguous_peers: usize,
+}
+
+/// Per-rule inverse analysis with stable evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct RuleAnalysis {
+    /// Identity of the analyzed rule.
+    pub rule_id: RuleId,
+    /// LHS variables absent from the RHS (the residual schema).
+    pub erased_variables: Vec<String>,
+    /// Lossless versus existential backward behavior.
+    pub backward: BackwardKind,
+    /// Other rules whose RHS unifies with this rule's RHS.
+    pub rhs_ambiguity: Vec<RuleId>,
+    /// Conservative reversibility classifier.
+    pub reversibility: ReversibilityClass,
+    /// Structural branching estimate.
+    pub branching: BranchingEstimate,
+    /// Unsupported or unknown reasons. Empty for checked first-order
+    /// rules in 0.25; when non-empty, the classifier above was
+    /// reached with the listed caveats.
+    pub unsupported_reasons: Vec<String>,
+}
+
+/// System-wide inverse report.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct InverseReport {
+    /// Per-rule analysis, in system rule order.
+    pub rules: Vec<RuleAnalysis>,
+}
+
+/// Structural analyzer over [`BidirectionalSystem`]s.
+pub struct InverseAnalyzer;
+
+impl InverseAnalyzer {
+    /// Analyze every wrapped rule. Infallible: construction already
+    /// checked the rules and compiled their clauses; RHS non-overlap
+    /// is evidence, not an error.
+    pub fn analyze(system: &BidirectionalSystem) -> InverseReport {
+        let rules = system.rules();
+        // Pairwise RHS unifiability: ambiguity classes.
+        let mut ambiguity: Vec<Vec<RuleId>> = rules.iter().map(|_| Vec::new()).collect();
+        // RHS overlap probing is structural evidence, not budgeted
+        // search: default relation resources are sufficient because
+        // checked rules are already size-bounded.
+        let limits = RelationLimits::default();
+        let mut resources = RelationResources::new(&limits);
+        for i in 0..rules.len() {
+            for j in (i + 1)..rules.len() {
+                let overlap = unify(
+                    rules[i].forward().rhs(),
+                    rules[j].forward().rhs(),
+                    &mut resources,
+                )
+                .is_ok();
+                if overlap {
+                    ambiguity[i].push(rules[j].rule_id());
+                    ambiguity[j].push(rules[i].rule_id());
+                }
+            }
+        }
+        let analyses = rules
+            .iter()
+            .enumerate()
+            .map(|(index, rule)| {
+                let erased: Vec<String> = rule.clause().erased_variables().to_vec();
+                let peers = ambiguity[index].clone();
+                let backward = if erased.is_empty() {
+                    BackwardKind::Lossless
+                } else {
+                    BackwardKind::Existential
+                };
+                let reversibility = if !peers.is_empty() {
+                    ReversibilityClass::Ambiguous
+                } else if !erased.is_empty() {
+                    ReversibilityClass::LossyResidual
+                } else {
+                    ReversibilityClass::Reversible
+                };
+                RuleAnalysis {
+                    rule_id: rule.rule_id(),
+                    erased_variables: erased.clone(),
+                    backward,
+                    rhs_ambiguity: peers.clone(),
+                    reversibility,
+                    branching: BranchingEstimate {
+                        existentials: erased.len(),
+                        ambiguous_peers: peers.len(),
+                    },
+                    unsupported_reasons: Vec::new(),
+                }
+            })
+            .collect();
+        InverseReport { rules: analyses }
+    }
+}

--- a/amari-rewrite/src/analysis/mod.rs
+++ b/amari-rewrite/src/analysis/mod.rs
@@ -7,7 +7,13 @@
 //! synthesis. Critical pairs, LPO, and confluence land in later
 //! cohorts.
 
+mod inverse;
 mod unify;
+
+pub use inverse::{
+    BackwardKind, BranchingEstimate, InverseAnalyzer, InverseReport, ReversibilityClass,
+    RuleAnalysis,
+};
 
 // The module and its primary entry point share the name `unify`;
 // they live in different namespaces, so `analysis::unify(...)` calls

--- a/amari-rewrite/src/reversible/mod.rs
+++ b/amari-rewrite/src/reversible/mod.rs
@@ -11,6 +11,8 @@
 
 mod residual;
 mod step;
+mod system;
 
 pub use residual::RewriteResidual;
 pub use step::{ForwardTransition, ReversibleStep};
+pub use system::{BidirectionalRule, BidirectionalStep, BidirectionalSystem};

--- a/amari-rewrite/src/reversible/system.rs
+++ b/amari-rewrite/src/reversible/system.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Declarative bidirectional systems over checked rules, compiled
+//! clauses, and residual contracts.
+
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+use crate::analysis::InverseReport;
+use crate::error::{RewriteError, RewriteResult};
+use crate::inverse::{symbolic_predecessors, SymbolicPredecessor};
+use crate::relation::{BackwardClause, RelationLimits, RuleId};
+use crate::reversible::{ForwardTransition, ReversibleStep, RewriteResidual};
+use crate::rewritable::Path;
+use crate::trs::{match_pattern, Rule, Term, TermSystem};
+
+/// A checked forward rule together with its compiled backward clause.
+///
+/// Runtime composite, not wire authority: serialization lives on the
+/// residual/step/report types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BidirectionalRule {
+    forward: Rule,
+    clause: BackwardClause,
+}
+
+impl BidirectionalRule {
+    /// Compile a checked rule and its backward contract.
+    pub fn compile(rule: Rule) -> RewriteResult<Self> {
+        let clause = BackwardClause::compile(&rule)?;
+        Ok(Self {
+            forward: rule,
+            clause,
+        })
+    }
+
+    /// The checked forward rule.
+    pub fn forward(&self) -> &Rule {
+        &self.forward
+    }
+
+    /// The compiled backward contract.
+    pub fn clause(&self) -> &BackwardClause {
+        &self.clause
+    }
+
+    /// Canonical rule identity.
+    pub fn rule_id(&self) -> RuleId {
+        self.clause.rule_id()
+    }
+}
+
+/// A forward step through a [`BidirectionalSystem`], with the residual
+/// present exactly when requested.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BidirectionalStep {
+    /// The rewritten term.
+    pub target: Term,
+    /// The local transition performed.
+    pub transition: ForwardTransition,
+    /// Typed residual authority, present iff requested.
+    pub residual: Option<RewriteResidual>,
+}
+
+/// A declarative bidirectional system: checked forward rules wrapped
+/// with compiled backward clauses and residual contracts.
+///
+/// Runtime composite, not wire authority: serialization lives on the
+/// residual/step/report types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BidirectionalSystem {
+    rules: Vec<BidirectionalRule>,
+    forward_system: TermSystem,
+}
+
+impl BidirectionalSystem {
+    /// Wrap checked forward rules with their backward contracts.
+    pub fn new(rules: Vec<Rule>) -> RewriteResult<Self> {
+        let compiled: Vec<BidirectionalRule> = rules
+            .iter()
+            .cloned()
+            .map(BidirectionalRule::compile)
+            .collect::<RewriteResult<_>>()?;
+        Ok(Self {
+            rules: compiled,
+            forward_system: TermSystem::new(rules),
+        })
+    }
+
+    /// The wrapped rules with their compiled clauses.
+    pub fn rules(&self) -> &[BidirectionalRule] {
+        &self.rules
+    }
+
+    /// The underlying forward system.
+    pub fn forward_system(&self) -> &TermSystem {
+        &self.forward_system
+    }
+
+    /// Concrete forward step by rule identity at `position`. When
+    /// `residual` is true, full typed residual authority is emitted.
+    pub fn forward_step(
+        &self,
+        source: &Term,
+        rule_id: &RuleId,
+        position: &Path,
+        residual: bool,
+        limits: &RelationLimits,
+    ) -> RewriteResult<BidirectionalStep> {
+        let rule = self
+            .rules
+            .iter()
+            .find(|rule| rule.rule_id() == *rule_id)
+            .ok_or_else(|| RewriteError::NoRule {
+                rule_name: rule_id.to_string(),
+            })?;
+        if residual {
+            let step = ReversibleStep::apply(
+                &self.forward_system,
+                source,
+                rule.forward(),
+                position,
+                limits,
+            )?;
+            return Ok(BidirectionalStep {
+                target: step.target,
+                transition: step.transition,
+                residual: Some(step.residual),
+            });
+        }
+        let subterm = source.subterm(position).ok_or(RewriteError::InvalidPath)?;
+        let substitution =
+            match_pattern(rule.forward().lhs(), subterm).ok_or(RewriteError::NoRule {
+                rule_name: rule_id.to_string(),
+            })?;
+        let target_subterm = substitution.apply(rule.forward().rhs());
+        let target = source.replace_at(position, target_subterm.clone())?;
+        Ok(BidirectionalStep {
+            target,
+            transition: ForwardTransition {
+                rule_id: *rule_id,
+                position: position.clone(),
+                from: subterm.clone(),
+                to: target_subterm,
+            },
+            residual: None,
+        })
+    }
+
+    /// The symbolic predecessor relation over checked clauses.
+    pub fn predecessors(
+        &self,
+        target: &Term,
+        limits: &RelationLimits,
+        scope: u32,
+    ) -> RewriteResult<Vec<SymbolicPredecessor>> {
+        symbolic_predecessors(&self.forward_system, target, limits, scope)
+    }
+
+    /// Exact backward replay with residual authority.
+    pub fn replay(
+        &self,
+        residual: &RewriteResidual,
+        target: &Term,
+        limits: &RelationLimits,
+    ) -> RewriteResult<Term> {
+        residual.replay(&self.forward_system, target, limits)
+    }
+
+    /// Structural reversibility/information-loss report.
+    pub fn reversibility(&self) -> InverseReport {
+        crate::analysis::InverseAnalyzer::analyze(self)
+    }
+}

--- a/amari-rewrite/tests/bidirectional_system.rs
+++ b/amari-rewrite/tests/bidirectional_system.rs
@@ -1,0 +1,175 @@
+//! Bidirectional system contract tests (0.25 Cohort 2, Task 11).
+
+use amari_rewrite::relation::RelationLimits;
+use amari_rewrite::reversible::BidirectionalSystem;
+use amari_rewrite::trs::{Rule, Term};
+use amari_rewrite::RewriteError;
+
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+fn limits() -> RelationLimits {
+    RelationLimits::default()
+}
+
+fn root() -> amari_rewrite::rewritable::Path {
+    amari_rewrite::rewritable::Path::root()
+}
+
+fn rules(pairs: &[(&str, &str)]) -> Vec<Rule> {
+    pairs
+        .iter()
+        .map(|(l, r)| Rule::new(parse(l), parse(r)).unwrap())
+        .collect()
+}
+
+#[test]
+fn construction_rechecks_every_rule() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X, Y)", "g(X)"), ("h(X)", "k(X)")])).unwrap();
+    assert_eq!(sys.rules().len(), 2);
+    // Clauses are compiled up front: erased variables are known.
+    assert_eq!(sys.rules()[0].clause().erased_variables(), &["Y"]);
+    assert!(sys.rules()[1].clause().erased_variables().is_empty());
+}
+
+#[test]
+fn forward_step_with_optional_residual() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X, Y)", "g(X)")])).unwrap();
+    let rule_id = sys.rules()[0].rule_id();
+    let source = parse("f(a, b)");
+
+    let with = sys
+        .forward_step(&source, &rule_id, &root(), true, &limits())
+        .unwrap();
+    assert_eq!(with.target, parse("g(a)"));
+    let residual = with.residual.expect("residual requested");
+    assert_eq!(residual.erased_bindings[0].1, parse("b"));
+
+    let without = sys
+        .forward_step(&source, &rule_id, &root(), false, &limits())
+        .unwrap();
+    assert_eq!(without.target, with.target);
+    assert!(without.residual.is_none());
+}
+
+#[test]
+fn forward_step_rejects_unknown_identity_and_nonmatching_position() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X)", "g(X)")])).unwrap();
+    let bogus = amari_rewrite::relation::RuleId::from_rule(
+        &Rule::new(parse("p(X)"), parse("q(X)")).unwrap(),
+    );
+    assert!(matches!(
+        sys.forward_step(&parse("f(a)"), &bogus, &root(), true, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+            | Err(RewriteError::NoRule { .. })
+            | Err(RewriteError::InvalidRule { .. })
+    ));
+    let rule_id = sys.rules()[0].rule_id();
+    assert!(matches!(
+        sys.forward_step(&parse("c"), &rule_id, &root(), true, &limits()),
+        Err(RewriteError::NoRule { .. })
+    ));
+}
+
+#[test]
+fn symbolic_predecessor_relation_via_system() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X, Y)", "g(X)")])).unwrap();
+    let preds = sys.predecessors(&parse("g(a)"), &limits(), 61).unwrap();
+    assert_eq!(preds.len(), 1);
+    assert_eq!(preds[0].existentials.len(), 1);
+    assert_eq!(preds[0].term.positions().len(), 3);
+}
+
+#[test]
+fn exact_backward_replay_via_system() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X, Y)", "g(X)")])).unwrap();
+    let rule_id = sys.rules()[0].rule_id();
+    let source = parse("f(a, b)");
+    let step = sys
+        .forward_step(&source, &rule_id, &root(), true, &limits())
+        .unwrap();
+    let residual = step.residual.unwrap();
+    let back = sys.replay(&residual, &step.target, &limits()).unwrap();
+    assert_eq!(back, source);
+    // Replay rejects tampering through the same path.
+    let mut forged = residual.clone();
+    forged.erased_bindings[0].1 = parse("c");
+    assert!(matches!(
+        sys.replay(&forged, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+    // A residual from a different system does not replay here.
+    let other = BidirectionalSystem::new(rules(&[("h(X)", "g(X)")])).unwrap();
+    assert!(matches!(
+        other.replay(&residual, &step.target, &limits()),
+        Err(RewriteError::ResidualMismatch { .. })
+    ));
+}
+
+#[test]
+fn steps_compose_through_typed_derivations() {
+    let sys = BidirectionalSystem::new(rules(&[("f(X)", "g(X)"), ("g(X)", "h(X)")])).unwrap();
+    let ids: Vec<_> = sys.rules().iter().map(|r| r.rule_id()).collect();
+    let s0 = parse("f(a)");
+    let step1 = sys
+        .forward_step(&s0, &ids[0], &root(), true, &limits())
+        .unwrap();
+    let step2 = sys
+        .forward_step(&step1.target, &ids[1], &root(), true, &limits())
+        .unwrap();
+    assert_eq!(step2.target, parse("h(a)"));
+    // Replay in reverse order reconstructs the original source.
+    let s1 = sys
+        .replay(&step2.residual.unwrap(), &step2.target, &limits())
+        .unwrap();
+    assert_eq!(s1, step1.target);
+    let back = sys
+        .replay(&step1.residual.unwrap(), &s1, &limits())
+        .unwrap();
+    assert_eq!(back, s0);
+}
+
+#[test]
+fn reversibility_report_is_structural_and_honest() {
+    let sys = BidirectionalSystem::new(rules(&[
+        ("f(X)", "g(X)"),
+        ("f(X, Y)", "g(X)"),
+        ("h(X)", "k(X)"),
+    ]))
+    .unwrap();
+    let report = sys.reversibility();
+    assert_eq!(report.rules.len(), 3);
+    // h(X) -> k(X): lossless and unambiguous.
+    let lossless = &report.rules[2];
+    assert!(lossless.erased_variables.is_empty());
+    // f(X,Y) -> g(X) is lossy; f(X) -> g(X) shares a unifiable RHS.
+    let erased = &report.rules[1];
+    assert_eq!(erased.erased_variables, vec!["Y".to_string()]);
+    assert!(!report.rules[0].rhs_ambiguity.is_empty());
+    assert!(!report.rules[1].rhs_ambiguity.is_empty());
+}

--- a/amari-rewrite/tests/inverse_analysis.rs
+++ b/amari-rewrite/tests/inverse_analysis.rs
@@ -1,0 +1,151 @@
+//! Inverse analysis contract tests (0.25 Cohort 2, Task 11).
+
+use amari_rewrite::analysis::{BackwardKind, InverseAnalyzer, ReversibilityClass};
+use amari_rewrite::reversible::BidirectionalSystem;
+use amari_rewrite::trs::{Rule, Term};
+
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+fn system(pairs: &[(&str, &str)]) -> BidirectionalSystem {
+    BidirectionalSystem::new(
+        pairs
+            .iter()
+            .map(|(l, r)| Rule::new(parse(l), parse(r)).unwrap())
+            .collect(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn lossless_rule_is_classified_reversible() {
+    let sys = system(&[("f(X)", "g(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    let analysis = &report.rules[0];
+    assert_eq!(analysis.backward, BackwardKind::Lossless);
+    assert!(analysis.erased_variables.is_empty());
+    assert!(analysis.rhs_ambiguity.is_empty());
+    assert_eq!(analysis.reversibility, ReversibilityClass::Reversible);
+    assert_eq!(analysis.branching.existentials, 0);
+    assert_eq!(analysis.branching.ambiguous_peers, 0);
+}
+
+#[test]
+fn erased_variables_drive_existential_backward() {
+    let sys = system(&[("f(X, Y)", "g(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    let analysis = &report.rules[0];
+    assert_eq!(analysis.backward, BackwardKind::Existential);
+    assert_eq!(analysis.erased_variables, vec!["Y".to_string()]);
+    assert_eq!(analysis.reversibility, ReversibilityClass::LossyResidual);
+    // One erased variable: finite-domain branching is the domain size
+    // per existential.
+    assert_eq!(analysis.branching.existentials, 1);
+}
+
+#[test]
+fn rhs_overlap_classes_are_reported_as_ambiguous() {
+    let sys = system(&[("f(X)", "g(X)"), ("h(X)", "g(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    // Both rules' RHS unify: both are Ambiguous, never Reversible.
+    for analysis in &report.rules {
+        assert_eq!(analysis.rhs_ambiguity.len(), 1);
+        assert_eq!(analysis.reversibility, ReversibilityClass::Ambiguous);
+        assert_eq!(analysis.branching.ambiguous_peers, 1);
+    }
+    // Distinct rule identities are reported, not merged.
+    assert_ne!(report.rules[0].rule_id, report.rules[1].rule_id);
+}
+
+#[test]
+fn lossy_and_ambiguous_reports_both_pieces_of_evidence() {
+    let sys = system(&[("f(X, Y)", "g(X)"), ("h(X)", "g(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    let first = &report.rules[0];
+    assert_eq!(first.backward, BackwardKind::Existential);
+    assert_eq!(first.reversibility, ReversibilityClass::Ambiguous);
+    assert_eq!(first.branching.existentials, 1);
+    assert_eq!(first.branching.ambiguous_peers, 1);
+}
+
+#[test]
+fn unifiable_rhs_structure_counts_as_ambiguity_not_identity() {
+    // g(X) and g(a) unify under substitution: ambiguous even though
+    // the rules are distinct and both lossless.
+    let sys = system(&[("f(X)", "g(X)"), ("h(X)", "g(a)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    for analysis in &report.rules {
+        assert_eq!(analysis.reversibility, ReversibilityClass::Ambiguous);
+    }
+}
+
+#[test]
+fn non_overlapping_rhs_is_not_flagged() {
+    let sys = system(&[("f(X)", "g(X)"), ("h(X, Y)", "k(X, Y)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    for analysis in &report.rules {
+        assert!(analysis.rhs_ambiguity.is_empty());
+    }
+}
+
+#[test]
+fn deterministic_branching_estimate_is_exact_for_lossless() {
+    // Lossless, unambiguous: backward branching is deterministic
+    // (zero existentials, zero ambiguous peers).
+    let sys = system(&[("f(X)", "g(X)"), ("h(X)", "k(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    for analysis in &report.rules {
+        assert_eq!(analysis.branching.existentials, 0);
+        assert_eq!(analysis.branching.ambiguous_peers, 0);
+        assert_eq!(analysis.reversibility, ReversibilityClass::Reversible);
+    }
+}
+
+#[test]
+fn unsupported_reasons_are_reported_never_hidden() {
+    // The 0.25 analyzer supports all checked first-order rules: the
+    // reasons list must be present and empty, not absent.
+    let sys = system(&[("f(X, Y)", "g(X)")]);
+    let report = InverseAnalyzer::analyze(&sys);
+    for analysis in &report.rules {
+        assert!(analysis.unsupported_reasons.is_empty());
+    }
+}
+
+#[test]
+fn exhaustive_enum_matches_are_stable() {
+    // Guard the typed surface: adding a variant must break this test.
+    let backward = [BackwardKind::Lossless, BackwardKind::Existential];
+    assert_eq!(backward.len(), 2);
+    let classes = [
+        ReversibilityClass::Reversible,
+        ReversibilityClass::LossyResidual,
+        ReversibilityClass::Ambiguous,
+    ];
+    assert_eq!(classes.len(), 3);
+}


### PR DESCRIPTION
# 0.25 Cohort 2, Task 11: bidirectional systems + inverse analysis

Per plan Task 11 and the design's bidirectional/inverse-analysis
sections.

## `reversible::system`

- **`BidirectionalRule`** — checked `Rule` + compiled `BackwardClause`
  (clauses compiled at construction, never lazily).
- **`BidirectionalSystem`** — `forward_step` with residual authority
  present **exactly when requested** (full authority path vs. cheap
  path); `predecessors` (symbolic relation), `replay` (exact backward
  with residual), `reversibility` (structural report).
- Composites are runtime types, not wire authority — serde stays on
  residual/step/report types (documented).

## `analysis::inverse` — `InverseAnalyzer`

Per rule, with stable evidence: erased variables (residual schema),
RHS overlap classes via **pairwise RHS unification** (unifiability,
not identity — `g(X)` vs `g(a)` is correctly ambiguous),
`BackwardKind::{Lossless, Existential}`, conservative
`ReversibilityClass::{Reversible, Ambiguous, LossyResidual}` —
**Reversible only when lossless AND unambiguous** (no false
functional-inverse claim), `BranchingEstimate{existentials,
ambiguous_peers}`, and an explicit `unsupported_reasons` list (empty
in 0.25, never absent).

## Evidence

RED→GREEN; 7 system tests + 9 analysis tests including a two-step
typed-derivation composition round trip and exhaustive-enum stability
guards. Matrix: 84 default/no-default, 88 serialize, 24/24
all-features; MSRV 1.89; clippy `-D warnings` ×2; rustdoc
`-D warnings`; catalog post-fmt (`83ccd175`, shard 20/20); verifiers
PASS.

Next: Task 12 — discovery/probe surfacing + the real `relation!`
macro, then Cohort 2 closeout review.
