### PR TITLE
feat: define inverse search states (0.25 Cohort 3, Task 13)

### DIFF
--- a/amari-discovery/catalog/generated.json
+++ b/amari-discovery/catalog/generated.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "version": "0.24.1",
   "description": "Generated structural catalog for Amari 0.24.1: 28 crates, 107 dependency edges",
-  "content_hash": "a32dd7d66e9d8a704fd7d8292cba730b4880d0567a1e95e43df36d9c8e037075",
+  "content_hash": "db89ca1d9880f1f5b37cc7f4db7b48fc167fb6d9c923c8f2557429679c1fdbf5",
   "crates": [
     {
       "name": "amari",
@@ -375543,6 +375543,133 @@
           ]
         },
         {
+          "path": "amari_rewrite::inverse::ApproximateSearchEvidence",
+          "kind": "struct",
+          "signature": "pub struct ApproximateSearchEvidence",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "summary",
+                "ty": "String"
+              },
+              {
+                "label": "explored_states",
+                "ty": "u64"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct ApproximateSearchEvidence",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "summary",
+                    "ty": "String"
+                  },
+                  {
+                    "label": "explored_states",
+                    "ty": "u64"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "ApproximateSearchEvidence"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::BackwardDerivation",
+          "kind": "struct",
+          "signature": "pub struct BackwardDerivation",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "steps",
+                "ty": "Vec < SymbolicPredecessor >"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BackwardDerivation",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "steps",
+                    "ty": "Vec < SymbolicPredecessor >"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "BackwardDerivation"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::BackwardFrontier",
+          "kind": "struct",
+          "signature": "pub struct BackwardFrontier",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "states",
+                "ty": "Vec < SymbolicState >"
+              },
+              {
+                "label": "depth_reached",
+                "ty": "u64"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct BackwardFrontier",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "states",
+                    "ty": "Vec < SymbolicState >"
+                  },
+                  {
+                    "label": "depth_reached",
+                    "ty": "u64"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "BackwardFrontier"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::inverse::BackwardProvenance",
           "kind": "struct",
           "signature": "pub struct BackwardProvenance",
@@ -375696,6 +375823,905 @@
           ]
         },
         {
+          "path": "amari_rewrite::inverse::BackwardSearchOutcome",
+          "kind": "enum",
+          "signature": "pub enum BackwardSearchOutcome",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "Witness",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "BackwardDerivation"
+                  ]
+                }
+              },
+              {
+                "name": "Exhausted",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "CertifiedExhaustion"
+                  ]
+                }
+              },
+              {
+                "name": "Partial",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "BackwardFrontier"
+                  ]
+                }
+              },
+              {
+                "name": "Approximate",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "ApproximateSearchEvidence"
+                  ]
+                }
+              },
+              {
+                "name": "Unsupported",
+                "data": {
+                  "kind": "tuple",
+                  "types": [
+                    "UnsupportedRelation"
+                  ]
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum BackwardSearchOutcome",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "Witness",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "BackwardDerivation"
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Exhausted",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "CertifiedExhaustion"
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Partial",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "BackwardFrontier"
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Approximate",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "ApproximateSearchEvidence"
+                      ]
+                    }
+                  },
+                  {
+                    "name": "Unsupported",
+                    "data": {
+                      "kind": "tuple",
+                      "types": [
+                        "UnsupportedRelation"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "BackwardSearchOutcome"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion",
+          "kind": "struct",
+          "signature": "pub struct CertifiedExhaustion",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct CertifiedExhaustion",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "CertifiedExhaustion"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion::authority",
+          "kind": "method",
+          "signature": "pub fn authority (& self) -> & ExhaustionAuthority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn authority (& self) -> & ExhaustionAuthority",
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "CertifiedExhaustion::authority"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion::evidence_hash",
+          "kind": "method",
+          "signature": "pub fn evidence_hash (& self) -> Sha256Digest",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn evidence_hash (& self) -> Sha256Digest",
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "CertifiedExhaustion::evidence_hash"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::ExhaustionAuthority",
+          "kind": "enum",
+          "signature": "pub enum ExhaustionAuthority",
+          "shape": {
+            "kind": "enum",
+            "variants": [
+              {
+                "name": "FiniteGroundingDomain",
+                "data": {
+                  "kind": "unit"
+                }
+              },
+              {
+                "name": "RegularLanguageExclusion",
+                "data": {
+                  "kind": "unit"
+                }
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "enum",
+              "signature": "pub enum ExhaustionAuthority",
+              "shape": {
+                "kind": "enum",
+                "variants": [
+                  {
+                    "name": "FiniteGroundingDomain",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  },
+                  {
+                    "name": "RegularLanguageExclusion",
+                    "data": {
+                      "kind": "unit"
+                    }
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "ExhaustionAuthority"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig",
+          "kind": "struct",
+          "signature": "pub struct InverseSearchConfig",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct InverseSearchConfig",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_CONSTRAINTS",
+          "kind": "const",
+          "signature": "pub const MAX_CONSTRAINTS : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_CONSTRAINTS : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_CONSTRAINTS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_DEPTH",
+          "kind": "const",
+          "signature": "pub const MAX_DEPTH : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_DEPTH : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_DEPTH"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_GROUNDINGS",
+          "kind": "const",
+          "signature": "pub const MAX_GROUNDINGS : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_GROUNDINGS : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_GROUNDINGS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_OPERATIONS",
+          "kind": "const",
+          "signature": "pub const MAX_OPERATIONS : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_OPERATIONS : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_OPERATIONS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_RETAINED_BYTES",
+          "kind": "const",
+          "signature": "pub const MAX_RETAINED_BYTES : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_RETAINED_BYTES : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_RETAINED_BYTES"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_STATES",
+          "kind": "const",
+          "signature": "pub const MAX_STATES : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_STATES : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_STATES"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TERM_DEPTH",
+          "kind": "const",
+          "signature": "pub const MAX_TERM_DEPTH : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TERM_DEPTH : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_TERM_DEPTH"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TERM_NODES",
+          "kind": "const",
+          "signature": "pub const MAX_TERM_NODES : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TERM_NODES : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_TERM_NODES"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TRACE_BYTES",
+          "kind": "const",
+          "signature": "pub const MAX_TRACE_BYTES : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TRACE_BYTES : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_TRACE_BYTES"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TRANSITIONS",
+          "kind": "const",
+          "signature": "pub const MAX_TRANSITIONS : u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "const",
+              "signature": "pub const MAX_TRANSITIONS : u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::MAX_TRANSITIONS"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_constraints",
+          "kind": "method",
+          "signature": "pub fn max_constraints (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_constraints (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_depth",
+          "kind": "method",
+          "signature": "pub fn max_depth (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_depth (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_depth"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_frontier_bytes",
+          "kind": "method",
+          "signature": "pub fn max_frontier_bytes (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_frontier_bytes (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_frontier_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_groundings",
+          "kind": "method",
+          "signature": "pub fn max_groundings (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_groundings (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_groundings"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_operations",
+          "kind": "method",
+          "signature": "pub fn max_operations (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_operations (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_states",
+          "kind": "method",
+          "signature": "pub fn max_states (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_states (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_states"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_term_depth",
+          "kind": "method",
+          "signature": "pub fn max_term_depth (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_term_depth (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_term_depth"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_term_nodes",
+          "kind": "method",
+          "signature": "pub fn max_term_nodes (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_term_nodes (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_term_nodes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_trace_bytes",
+          "kind": "method",
+          "signature": "pub fn max_trace_bytes (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_trace_bytes (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_trace_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_transitions",
+          "kind": "method",
+          "signature": "pub fn max_transitions (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn max_transitions (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::max_transitions"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::new",
+          "kind": "method",
+          "signature": "pub fn new (max_depth : u64 , max_states : u64 , max_transitions : u64 , max_term_nodes : u64 , max_term_depth : u64 , max_constraints : u64 , max_groundings : u64 , max_operations : u64 , max_frontier_bytes : u64 , max_trace_bytes : u64 ,) -> RewriteResult < Self >",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::config",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (max_depth : u64 , max_states : u64 , max_transitions : u64 , max_term_nodes : u64 , max_term_depth : u64 , max_constraints : u64 , max_groundings : u64 , max_operations : u64 , max_frontier_bytes : u64 , max_trace_bytes : u64 ,) -> RewriteResult < Self >",
+              "source_path": "amari-rewrite/src/inverse/config.rs",
+              "source_module": "amari_rewrite::inverse::config",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::config",
+              "declaration_ident": "InverseSearchConfig::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources",
+          "kind": "struct",
+          "signature": "pub struct SearchResources",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct SearchResources",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::new",
+          "kind": "method",
+          "signature": "pub fn new (config : & crate :: inverse :: InverseSearchConfig) -> Self",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (config : & crate :: inverse :: InverseSearchConfig) -> Self",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::operations",
+          "kind": "method",
+          "signature": "pub fn operations (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn operations (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_bytes",
+          "kind": "method",
+          "signature": "pub fn record_bytes (& mut self , bytes : u64) -> crate :: RewriteResult < () >",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_bytes (& mut self , bytes : u64) -> crate :: RewriteResult < () >",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::record_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_operations",
+          "kind": "method",
+          "signature": "pub fn record_operations (& mut self , count : u64) -> crate :: RewriteResult < () >",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_operations (& mut self , count : u64) -> crate :: RewriteResult < () >",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::record_operations"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_state",
+          "kind": "method",
+          "signature": "pub fn record_state (& mut self) -> crate :: RewriteResult < () >",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_state (& mut self) -> crate :: RewriteResult < () >",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::record_state"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_trace",
+          "kind": "method",
+          "signature": "pub fn record_trace (& mut self , bytes : u64) -> crate :: RewriteResult < () >",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_trace (& mut self , bytes : u64) -> crate :: RewriteResult < () >",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::record_trace"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_transition",
+          "kind": "method",
+          "signature": "pub fn record_transition (& mut self) -> crate :: RewriteResult < () >",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn record_transition (& mut self) -> crate :: RewriteResult < () >",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::record_transition"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::retained_bytes",
+          "kind": "method",
+          "signature": "pub fn retained_bytes (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn retained_bytes (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::retained_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::states",
+          "kind": "method",
+          "signature": "pub fn states (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn states (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::states"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::trace_bytes",
+          "kind": "method",
+          "signature": "pub fn trace_bytes (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn trace_bytes (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::trace_bytes"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::transitions",
+          "kind": "method",
+          "signature": "pub fn transitions (& self) -> u64",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn transitions (& self) -> u64",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SearchResources::transitions"
+            }
+          ]
+        },
+        {
           "path": "amari_rewrite::inverse::SymbolicPredecessor",
           "kind": "struct",
           "signature": "pub struct SymbolicPredecessor",
@@ -375769,6 +376795,146 @@
               "is_reexport": false,
               "declaration_module": "amari_rewrite::inverse",
               "declaration_ident": "SymbolicPredecessor"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState",
+          "kind": "struct",
+          "signature": "pub struct SymbolicState",
+          "shape": {
+            "kind": "struct",
+            "fields": []
+          },
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct SymbolicState",
+              "shape": {
+                "kind": "struct",
+                "fields": []
+              },
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SymbolicState"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::canonical_digest",
+          "kind": "method",
+          "signature": "pub fn canonical_digest (& self) -> Sha256Digest",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn canonical_digest (& self) -> Sha256Digest",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SymbolicState::canonical_digest"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::constraints",
+          "kind": "method",
+          "signature": "pub fn constraints (& self) -> & ConstraintSet",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn constraints (& self) -> & ConstraintSet",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SymbolicState::constraints"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::new",
+          "kind": "method",
+          "signature": "pub fn new (term : Term , constraints : ConstraintSet) -> Self",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn new (term : Term , constraints : ConstraintSet) -> Self",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SymbolicState::new"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::term",
+          "kind": "method",
+          "signature": "pub fn term (& self) -> & Term",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::state",
+          "variants": [
+            {
+              "kind": "method",
+              "signature": "pub fn term (& self) -> & Term",
+              "source_path": "amari-rewrite/src/inverse/state.rs",
+              "source_module": "amari_rewrite::inverse::state",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::state",
+              "declaration_ident": "SymbolicState::term"
+            }
+          ]
+        },
+        {
+          "path": "amari_rewrite::inverse::UnsupportedRelation",
+          "kind": "struct",
+          "signature": "pub struct UnsupportedRelation",
+          "shape": {
+            "kind": "struct",
+            "fields": [
+              {
+                "label": "reason",
+                "ty": "String"
+              }
+            ]
+          },
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "is_reexport": true,
+          "source_module": "amari_rewrite::inverse::outcome",
+          "variants": [
+            {
+              "kind": "struct",
+              "signature": "pub struct UnsupportedRelation",
+              "shape": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "label": "reason",
+                    "ty": "String"
+                  }
+                ]
+              },
+              "source_path": "amari-rewrite/src/inverse/outcome.rs",
+              "source_module": "amari_rewrite::inverse::outcome",
+              "is_reexport": true,
+              "declaration_module": "amari_rewrite::inverse::outcome",
+              "declaration_ident": "UnsupportedRelation"
             }
           ]
         },
@@ -381696,6 +382862,60 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::ApproximateSearchEvidence",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ApproximateSearchEvidence"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::BackwardDerivation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardDerivation"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::BackwardFrontier",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardFrontier"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 4,
@@ -381714,6 +382934,96 @@
         },
         {
           "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::BackwardSearchOutcome",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 7,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardSearchOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::CertifiedExhaustion",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "CertifiedExhaustion"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::ExhaustionAuthority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ExhaustionAuthority"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::SearchResources",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 8,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SearchResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
           "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 5,
@@ -381725,6 +383035,42 @@
             "kind": "local",
             "module": "amari_rewrite::inverse",
             "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Clone",
+          "impl_type_path": "amari_rewrite::inverse::UnsupportedRelation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 6,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Clone"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "UnsupportedRelation"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382463,6 +383809,24 @@
             "kind": "local",
             "module": "amari_rewrite::ars",
             "ident": "Strategy"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Copy",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Copy"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -382759,6 +384123,60 @@
         },
         {
           "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::ApproximateSearchEvidence",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ApproximateSearchEvidence"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::BackwardDerivation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardDerivation"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::BackwardFrontier",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardFrontier"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
           "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 4,
@@ -382777,6 +384195,96 @@
         },
         {
           "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::BackwardSearchOutcome",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 7,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardSearchOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::CertifiedExhaustion",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "CertifiedExhaustion"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::ExhaustionAuthority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ExhaustionAuthority"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::SearchResources",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 8,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SearchResources"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
           "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 5,
@@ -382788,6 +384296,42 @@
             "kind": "local",
             "module": "amari_rewrite::inverse",
             "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Debug",
+          "impl_type_path": "amari_rewrite::inverse::UnsupportedRelation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 6,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Debug"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "UnsupportedRelation"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -383458,6 +385002,24 @@
           "unsafe_trait": false,
           "negative": false,
           "is_derived": true
+        },
+        {
+          "trait_path": "Default",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Default"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
         },
         {
           "trait_path": "Default",
@@ -383858,6 +385420,24 @@
         },
         {
           "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
           "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 5,
@@ -383873,6 +385453,24 @@
           "unsafe_trait": false,
           "negative": false,
           "is_derived": true
+        },
+        {
+          "trait_path": "Eq",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 4,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Eq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
         },
         {
           "trait_path": "Eq",
@@ -384815,6 +386413,24 @@
         },
         {
           "trait_path": "Hash",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 7,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Hash"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "Hash",
           "impl_type_path": "amari_rewrite::prelude::Path",
           "source_path": "amari-rewrite/src/rewritable.rs",
           "source_ordinal": 0,
@@ -385046,6 +386662,24 @@
           "unsafe_trait": false,
           "negative": false,
           "is_derived": true
+        },
+        {
+          "trait_path": "Ord",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 6,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "Ord"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
         },
         {
           "trait_path": "Ord",
@@ -385410,6 +387044,60 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::ApproximateSearchEvidence",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ApproximateSearchEvidence"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::BackwardDerivation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardDerivation"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::BackwardFrontier",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 1,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardFrontier"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::inverse::BackwardProvenance",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 4,
@@ -385428,6 +387116,78 @@
         },
         {
           "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::BackwardSearchOutcome",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 7,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "BackwardSearchOutcome"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::CertifiedExhaustion",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 2,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "CertifiedExhaustion"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::ExhaustionAuthority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "ExhaustionAuthority"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::config",
+            "ident": "InverseSearchConfig"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
           "impl_type_path": "amari_rewrite::inverse::SymbolicPredecessor",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 5,
@@ -385439,6 +387199,42 @@
             "kind": "local",
             "module": "amari_rewrite::inverse",
             "ident": "SymbolicPredecessor"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": true
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 3,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
+        },
+        {
+          "trait_path": "PartialEq",
+          "impl_type_path": "amari_rewrite::inverse::UnsupportedRelation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 6,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialEq"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::outcome",
+            "ident": "UnsupportedRelation"
           },
           "unsafe_trait": false,
           "negative": false,
@@ -386091,6 +387887,24 @@
           "unsafe_trait": false,
           "negative": false,
           "is_derived": true
+        },
+        {
+          "trait_path": "PartialOrd",
+          "impl_type_path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 5,
+          "trait_endpoint": {
+            "kind": "external",
+            "path": "PartialOrd"
+          },
+          "impl_type_endpoint": {
+            "kind": "local",
+            "module": "amari_rewrite::inverse::state",
+            "ident": "SymbolicState"
+          },
+          "unsafe_trait": false,
+          "negative": false,
+          "is_derived": false
         },
         {
           "trait_path": "PartialOrd",
@@ -386829,6 +388643,30 @@
           "surface_kind": "module"
         },
         {
+          "path": "amari_rewrite::inverse::ApproximateSearchEvidence",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::BackwardDerivation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::BackwardFrontier",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
           "path": "amari_rewrite::inverse::BackwardProvenance",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 4,
@@ -386869,9 +388707,369 @@
           "surface_kind": "inherent_method"
         },
         {
+          "path": "amari_rewrite::inverse::BackwardSearchOutcome",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 7,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion::authority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::CertifiedExhaustion::evidence_hash",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::ExhaustionAuthority",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_CONSTRAINTS",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_DEPTH",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_GROUNDINGS",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_OPERATIONS",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 7,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_RETAINED_BYTES",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_STATES",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TERM_DEPTH",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TERM_NODES",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TRACE_BYTES",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 9,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::MAX_TRANSITIONS",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_const"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_constraints",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 17,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_depth",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 12,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_frontier_bytes",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 20,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_groundings",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 18,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_operations",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 19,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_states",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 13,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_term_depth",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 16,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_term_nodes",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 15,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_trace_bytes",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 21,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::max_transitions",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 14,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::InverseSearchConfig::new",
+          "source_path": "amari-rewrite/src/inverse/config.rs",
+          "source_ordinal": 10,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::new",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::operations",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 11,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_bytes",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 4,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_operations",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 6,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_state",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_trace",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::record_transition",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::retained_bytes",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 9,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::states",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 7,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::trace_bytes",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 10,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SearchResources::transitions",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 8,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
           "path": "amari_rewrite::inverse::SymbolicPredecessor",
           "source_path": "amari-rewrite/src/inverse/mod.rs",
           "source_ordinal": 5,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "top_level"
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::canonical_digest",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 3,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::constraints",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 2,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::new",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 0,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::SymbolicState::term",
+          "source_path": "amari-rewrite/src/inverse/state.rs",
+          "source_ordinal": 1,
+          "gate": "always",
+          "status": "enabled",
+          "surface_kind": "inherent_method"
+        },
+        {
+          "path": "amari_rewrite::inverse::UnsupportedRelation",
+          "source_path": "amari-rewrite/src/inverse/outcome.rs",
+          "source_ordinal": 6,
           "gate": "always",
           "status": "enabled",
           "surface_kind": "top_level"

--- a/amari-rewrite/src/inverse/config.rs
+++ b/amari-rewrite/src/inverse/config.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Inverse search configuration with fixed ceilings.
+//!
+//! Caller-supplied values below the ceilings tighten the search;
+//! zero or above-ceiling values are typed errors. Ceilings are
+//! associated constants and cannot be raised by callers (design
+//! resource-authority table: 65,536 states, 262,144 transitions,
+//! depth 64, 64 MiB retained evidence).
+
+use crate::error::{RewriteError, RewriteResult};
+
+/// Bounded configuration for backward/bidirectional inverse search.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(deny_unknown_fields)
+)]
+pub struct InverseSearchConfig {
+    max_depth: u64,
+    max_states: u64,
+    max_transitions: u64,
+    max_term_nodes: u64,
+    max_term_depth: u64,
+    max_constraints: u64,
+    max_groundings: u64,
+    max_operations: u64,
+    max_frontier_bytes: u64,
+    max_trace_bytes: u64,
+}
+
+impl InverseSearchConfig {
+    /// Hard ceiling on search depth.
+    pub const MAX_DEPTH: u64 = 64;
+    /// Hard ceiling on retained states.
+    pub const MAX_STATES: u64 = 65_536;
+    /// Hard ceiling on explored transitions.
+    pub const MAX_TRANSITIONS: u64 = 262_144;
+    /// Hard ceiling on term nodes.
+    pub const MAX_TERM_NODES: u64 = 4_096;
+    /// Hard ceiling on term depth.
+    pub const MAX_TERM_DEPTH: u64 = 64;
+    /// Hard ceiling on constraints per state.
+    pub const MAX_CONSTRAINTS: u64 = 4_096;
+    /// Hard ceiling on grounding assignments.
+    pub const MAX_GROUNDINGS: u64 = 65_536;
+    /// Hard ceiling on abstract operations.
+    pub const MAX_OPERATIONS: u64 = 1_000_000;
+    /// Hard ceiling on retained frontier evidence bytes (64 MiB).
+    pub const MAX_RETAINED_BYTES: u64 = 64 * 1024 * 1024;
+    /// Hard ceiling on trace bytes (64 MiB).
+    pub const MAX_TRACE_BYTES: u64 = 64 * 1024 * 1024;
+
+    /// Validate a search configuration. Zero or above-ceiling values
+    /// are [`RewriteError::InvalidLimit`] errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        max_depth: u64,
+        max_states: u64,
+        max_transitions: u64,
+        max_term_nodes: u64,
+        max_term_depth: u64,
+        max_constraints: u64,
+        max_groundings: u64,
+        max_operations: u64,
+        max_frontier_bytes: u64,
+        max_trace_bytes: u64,
+    ) -> RewriteResult<Self> {
+        let config = Self {
+            max_depth,
+            max_states,
+            max_transitions,
+            max_term_nodes,
+            max_term_depth,
+            max_constraints,
+            max_groundings,
+            max_operations,
+            max_frontier_bytes,
+            max_trace_bytes,
+        };
+        config.check("search depth", config.max_depth, Self::MAX_DEPTH)?;
+        config.check("search states", config.max_states, Self::MAX_STATES)?;
+        config.check(
+            "search transitions",
+            config.max_transitions,
+            Self::MAX_TRANSITIONS,
+        )?;
+        config.check(
+            "search term nodes",
+            config.max_term_nodes,
+            Self::MAX_TERM_NODES,
+        )?;
+        config.check(
+            "search term depth",
+            config.max_term_depth,
+            Self::MAX_TERM_DEPTH,
+        )?;
+        config.check(
+            "search constraints",
+            config.max_constraints,
+            Self::MAX_CONSTRAINTS,
+        )?;
+        config.check(
+            "search groundings",
+            config.max_groundings,
+            Self::MAX_GROUNDINGS,
+        )?;
+        config.check(
+            "search operations",
+            config.max_operations,
+            Self::MAX_OPERATIONS,
+        )?;
+        config.check(
+            "search frontier bytes",
+            config.max_frontier_bytes,
+            Self::MAX_RETAINED_BYTES,
+        )?;
+        config.check(
+            "search trace bytes",
+            config.max_trace_bytes,
+            Self::MAX_TRACE_BYTES,
+        )?;
+        Ok(config)
+    }
+
+    fn check(&self, resource: &'static str, value: u64, ceiling: u64) -> RewriteResult<()> {
+        if value == 0 || value > ceiling {
+            return Err(RewriteError::InvalidLimit {
+                resource,
+                value: value as usize,
+                ceiling: ceiling as usize,
+            });
+        }
+        Ok(())
+    }
+
+    /// Search depth cap.
+    pub fn max_depth(&self) -> u64 {
+        self.max_depth
+    }
+
+    /// Retained-state cap.
+    pub fn max_states(&self) -> u64 {
+        self.max_states
+    }
+
+    /// Explored-transition cap.
+    pub fn max_transitions(&self) -> u64 {
+        self.max_transitions
+    }
+
+    /// Term-node cap.
+    pub fn max_term_nodes(&self) -> u64 {
+        self.max_term_nodes
+    }
+
+    /// Term-depth cap.
+    pub fn max_term_depth(&self) -> u64 {
+        self.max_term_depth
+    }
+
+    /// Per-state constraint cap.
+    pub fn max_constraints(&self) -> u64 {
+        self.max_constraints
+    }
+
+    /// Grounding-assignment cap.
+    pub fn max_groundings(&self) -> u64 {
+        self.max_groundings
+    }
+
+    /// Operation cap.
+    pub fn max_operations(&self) -> u64 {
+        self.max_operations
+    }
+
+    /// Retained frontier byte cap.
+    pub fn max_frontier_bytes(&self) -> u64 {
+        self.max_frontier_bytes
+    }
+
+    /// Trace byte cap.
+    pub fn max_trace_bytes(&self) -> u64 {
+        self.max_trace_bytes
+    }
+}
+
+impl Default for InverseSearchConfig {
+    /// Defaults sit at the fixed ceilings.
+    fn default() -> Self {
+        Self {
+            max_depth: Self::MAX_DEPTH,
+            max_states: Self::MAX_STATES,
+            max_transitions: Self::MAX_TRANSITIONS,
+            max_term_nodes: Self::MAX_TERM_NODES,
+            max_term_depth: Self::MAX_TERM_DEPTH,
+            max_constraints: Self::MAX_CONSTRAINTS,
+            max_groundings: Self::MAX_GROUNDINGS,
+            max_operations: Self::MAX_OPERATIONS,
+            max_frontier_bytes: Self::MAX_RETAINED_BYTES,
+            max_trace_bytes: Self::MAX_TRACE_BYTES,
+        }
+    }
+}

--- a/amari-rewrite/src/inverse/mod.rs
+++ b/amari-rewrite/src/inverse/mod.rs
@@ -7,6 +7,17 @@
 use alloc::collections::{BTreeSet, VecDeque};
 use alloc::vec::Vec;
 
+mod config;
+mod outcome;
+mod state;
+
+pub use config::InverseSearchConfig;
+pub use outcome::{
+    ApproximateSearchEvidence, BackwardDerivation, BackwardFrontier, BackwardSearchOutcome,
+    CertifiedExhaustion, ExhaustionAuthority, UnsupportedRelation,
+};
+pub use state::{SearchResources, SymbolicState};
+
 use crate::analysis::unify;
 use crate::error::RewriteResult;
 use crate::relation::{

--- a/amari-rewrite/src/inverse/outcome.rs
+++ b/amari-rewrite/src/inverse/outcome.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed backward-search outcomes.
+//!
+//! Outcomes are values, not booleans. `Exhausted` is only
+//! constructible with certified finite/exact authority: the type has
+//! no public constructor, so no caller can claim unreachability from
+//! a depth, node, or operation ceiling — those are always `Partial`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::inverse::{state::SymbolicState, SymbolicPredecessor};
+use crate::relation::Sha256Digest;
+
+/// A certified backward derivation: the predecessor chain witnessing
+/// that the goal is reachable.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BackwardDerivation {
+    /// Ordered derivation steps, each with full provenance.
+    pub steps: Vec<SymbolicPredecessor>,
+}
+
+/// The retained frontier when a search is cut by a budget.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct BackwardFrontier {
+    /// Unexpanded states at the cut point (alpha-canonical).
+    pub states: Vec<SymbolicState>,
+    /// Depth reached when the budget cut the search.
+    pub depth_reached: u64,
+}
+
+/// Certified finite/exact exhaustion authority. Constructible only
+/// inside this crate with certified evidence (a fully enumerated
+/// finite grounding domain, or an exact regular-language exclusion);
+/// the fields are private so callers cannot forge exhaustion.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct CertifiedExhaustion {
+    authority: ExhaustionAuthority,
+    evidence_hash: Sha256Digest,
+}
+
+/// The kind of exact authority behind a certified exhaustion.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum ExhaustionAuthority {
+    /// A finite grounding domain was completely enumerated.
+    FiniteGroundingDomain,
+    /// An exact regular-language exclusion proof.
+    RegularLanguageExclusion,
+}
+
+impl CertifiedExhaustion {
+    /// Crate-internal certification. Task 14+ construct this only
+    /// with the evidence named by `authority`.
+    // The BackwardExplorer (Task 14) is the first production caller;
+    // until then only the module test exercises certification.
+    #[allow(dead_code)]
+    pub(crate) fn certify(authority: ExhaustionAuthority, evidence: &[u8]) -> Self {
+        Self {
+            authority,
+            evidence_hash: Sha256Digest::framed("amari.inverse.exhaustion/v1", evidence),
+        }
+    }
+
+    /// The authority kind backing this exhaustion.
+    pub fn authority(&self) -> &ExhaustionAuthority {
+        &self.authority
+    }
+
+    /// Digest of the certified evidence.
+    pub fn evidence_hash(&self) -> Sha256Digest {
+        self.evidence_hash
+    }
+}
+
+/// Evidence for an approximate (non-exact) search result.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct ApproximateSearchEvidence {
+    /// What approximation was used and why.
+    pub summary: String,
+    /// States explored before the approximation was produced.
+    pub explored_states: u64,
+}
+
+/// A relation the 0.25 engines do not support, with the reason.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct UnsupportedRelation {
+    /// Why this relation is unsupported (never silent).
+    pub reason: String,
+}
+
+/// Typed outcome of a bounded backward search.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub enum BackwardSearchOutcome {
+    /// A certified derivation witnessing reachability.
+    Witness(BackwardDerivation),
+    /// Certified finite/exact exhaustion. Never constructible from
+    /// budget exhaustion.
+    Exhausted(CertifiedExhaustion),
+    /// Budget cut the search; the retained frontier is returned.
+    Partial(BackwardFrontier),
+    /// An approximate result with its evidence.
+    Approximate(ApproximateSearchEvidence),
+    /// The relation is unsupported; the reason is carried.
+    Unsupported(UnsupportedRelation),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn certified_exhaustion_carries_authority_and_evidence() {
+        let certified = CertifiedExhaustion::certify(
+            ExhaustionAuthority::FiniteGroundingDomain,
+            b"domain:3-terms",
+        );
+        assert_eq!(
+            certified.authority(),
+            &ExhaustionAuthority::FiniteGroundingDomain
+        );
+        assert_eq!(certified.evidence_hash().as_bytes().len(), 32);
+        let outcome = BackwardSearchOutcome::Exhausted(certified);
+        assert!(matches!(outcome, BackwardSearchOutcome::Exhausted(_)));
+    }
+}

--- a/amari-rewrite/src/inverse/state.rs
+++ b/amari-rewrite/src/inverse/state.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Alpha-canonical symbolic search states.
+//!
+//! A [`SymbolicState`] pairs a term (with freshened logic variables)
+//! with its constraint set. Equality, ordering, and hashing use a
+//! joint alpha-canonical digest: variables are renamed by first
+//! occurrence across the term AND the constraints in one pass, so
+//! alpha-equivalent states deduplicate while constraint differences
+//! always distinguish states.
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::cmp::Ordering;
+use core::hash::{Hash, Hasher};
+
+use crate::relation::digest::encode_term;
+use crate::relation::{ConstraintSet, Sha256Digest, TermConstraint};
+use crate::trs::Term;
+use crate::RewriteError;
+
+/// A symbolic search state: term plus residual constraints, compared
+/// by joint alpha-canonical digest.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct SymbolicState {
+    term: Term,
+    constraints: ConstraintSet,
+    digest: Sha256Digest,
+}
+
+impl SymbolicState {
+    /// Construct a state, computing its joint alpha-canonical digest.
+    pub fn new(term: Term, constraints: ConstraintSet) -> Self {
+        let digest = canonical_state_digest(&term, &constraints);
+        Self {
+            term,
+            constraints,
+            digest,
+        }
+    }
+
+    /// The state term (freshened variables as derived).
+    pub fn term(&self) -> &Term {
+        &self.term
+    }
+
+    /// Residual constraints on this state.
+    pub fn constraints(&self) -> &ConstraintSet {
+        &self.constraints
+    }
+
+    /// Joint alpha-canonical digest: the state's identity.
+    pub fn canonical_digest(&self) -> Sha256Digest {
+        self.digest
+    }
+}
+
+/// Joint alpha-canonical encoding: one variable-renaming pass shared
+/// by the term and every constraint, with constraint sides
+/// canonicalized (symmetric equality/disequality) and constraint
+/// encodings sorted.
+fn canonical_state_digest(term: &Term, constraints: &ConstraintSet) -> Sha256Digest {
+    let mut variables: Vec<String> = Vec::new();
+    let mut encoding = Vec::new();
+    encode_term(term, &mut variables, &mut encoding);
+    let mut constraint_blobs: Vec<Vec<u8>> = Vec::new();
+    for constraint in constraints.constraints() {
+        let (tag, left, right) = match constraint {
+            TermConstraint::Equal(left, right) => (0x10u8, left, right),
+            TermConstraint::NotEqual(left, right) => (0x11u8, left, right),
+        };
+        let mut left_bytes = Vec::new();
+        encode_term(left, &mut variables, &mut left_bytes);
+        let mut right_bytes = Vec::new();
+        encode_term(right, &mut variables, &mut right_bytes);
+        let mut blob = vec![tag];
+        if left_bytes <= right_bytes {
+            blob.extend_from_slice(&left_bytes);
+            blob.extend_from_slice(&right_bytes);
+        } else {
+            blob.extend_from_slice(&right_bytes);
+            blob.extend_from_slice(&left_bytes);
+        }
+        constraint_blobs.push(blob);
+    }
+    constraint_blobs.sort();
+    encoding.extend_from_slice(&(constraint_blobs.len() as u32).to_le_bytes());
+    for blob in constraint_blobs {
+        encoding.extend_from_slice(&(blob.len() as u32).to_le_bytes());
+        encoding.extend_from_slice(&blob);
+    }
+    Sha256Digest::framed("amari.relation.symbolic-state/v1", &encoding)
+}
+
+impl PartialEq for SymbolicState {
+    fn eq(&self, other: &Self) -> bool {
+        self.digest == other.digest
+    }
+}
+
+impl Eq for SymbolicState {}
+
+impl PartialOrd for SymbolicState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SymbolicState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.digest.as_bytes().cmp(other.digest.as_bytes())
+    }
+}
+
+impl Hash for SymbolicState {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.digest.as_bytes().hash(state);
+    }
+}
+
+/// Search resource counters with ceiling enforcement.
+#[derive(Clone, Debug)]
+pub struct SearchResources {
+    max_states: u64,
+    max_transitions: u64,
+    max_retained_bytes: u64,
+    max_trace_bytes: u64,
+    max_operations: u64,
+    states: u64,
+    transitions: u64,
+    retained_bytes: u64,
+    trace_bytes: u64,
+    operations: u64,
+}
+
+impl SearchResources {
+    /// Counters bound to a search configuration.
+    pub fn new(config: &crate::inverse::InverseSearchConfig) -> Self {
+        Self {
+            max_states: config.max_states(),
+            max_transitions: config.max_transitions(),
+            max_retained_bytes: config.max_frontier_bytes(),
+            max_trace_bytes: config.max_trace_bytes(),
+            max_operations: config.max_operations(),
+            states: 0,
+            transitions: 0,
+            retained_bytes: 0,
+            trace_bytes: 0,
+            operations: 0,
+        }
+    }
+
+    fn exceeded(resource: &'static str, limit: u64) -> RewriteError {
+        RewriteError::RelationLimitExceeded {
+            resource,
+            limit: limit as usize,
+        }
+    }
+
+    /// Account one retained state.
+    pub fn record_state(&mut self) -> crate::RewriteResult<()> {
+        if self.states >= self.max_states {
+            return Err(Self::exceeded("search states", self.max_states));
+        }
+        self.states += 1;
+        Ok(())
+    }
+
+    /// Account one explored transition.
+    pub fn record_transition(&mut self) -> crate::RewriteResult<()> {
+        if self.transitions >= self.max_transitions {
+            return Err(Self::exceeded("search transitions", self.max_transitions));
+        }
+        self.transitions += 1;
+        Ok(())
+    }
+
+    /// Account retained frontier bytes.
+    pub fn record_bytes(&mut self, bytes: u64) -> crate::RewriteResult<()> {
+        let next = self.retained_bytes.saturating_add(bytes);
+        if next > self.max_retained_bytes {
+            return Err(Self::exceeded(
+                "search retained bytes",
+                self.max_retained_bytes,
+            ));
+        }
+        self.retained_bytes = next;
+        Ok(())
+    }
+
+    /// Account trace bytes.
+    pub fn record_trace(&mut self, bytes: u64) -> crate::RewriteResult<()> {
+        let next = self.trace_bytes.saturating_add(bytes);
+        if next > self.max_trace_bytes {
+            return Err(Self::exceeded("search trace bytes", self.max_trace_bytes));
+        }
+        self.trace_bytes = next;
+        Ok(())
+    }
+
+    /// Account abstract operations.
+    pub fn record_operations(&mut self, count: u64) -> crate::RewriteResult<()> {
+        let next = self.operations.saturating_add(count);
+        if next > self.max_operations {
+            return Err(Self::exceeded("search operations", self.max_operations));
+        }
+        self.operations = next;
+        Ok(())
+    }
+
+    /// States retained so far.
+    pub fn states(&self) -> u64 {
+        self.states
+    }
+
+    /// Transitions explored so far.
+    pub fn transitions(&self) -> u64 {
+        self.transitions
+    }
+
+    /// Retained frontier bytes so far.
+    pub fn retained_bytes(&self) -> u64 {
+        self.retained_bytes
+    }
+
+    /// Trace bytes recorded so far.
+    pub fn trace_bytes(&self) -> u64 {
+        self.trace_bytes
+    }
+
+    /// Operations spent so far.
+    pub fn operations(&self) -> u64 {
+        self.operations
+    }
+}

--- a/amari-rewrite/tests/inverse_state.rs
+++ b/amari-rewrite/tests/inverse_state.rs
@@ -1,0 +1,161 @@
+//! Alpha-canonical symbolic search state contract tests
+//! (0.25 Cohort 3, Task 13).
+
+use std::collections::BTreeSet;
+
+use amari_rewrite::inverse::{
+    BackwardSearchOutcome, InverseSearchConfig, SearchResources, SymbolicState,
+};
+use amari_rewrite::relation::{ConstraintSet, TermConstraint};
+use amari_rewrite::trs::Term;
+use amari_rewrite::RewriteError;
+
+fn parse(text: &str) -> Term {
+    let text = text.trim();
+    if let Some(open) = text.find('(') {
+        let head = &text[..open];
+        let inner = &text[open + 1..text.len() - 1];
+        let mut args = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        for (index, ch) in inner.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                ',' if depth == 0 => {
+                    args.push(parse(&inner[start..index]));
+                    start = index + 1;
+                }
+                _ => {}
+            }
+        }
+        args.push(parse(&inner[start..]));
+        Term::sym(head, args)
+    } else if text.chars().next().is_some_and(char::is_uppercase) || text.starts_with('?') {
+        Term::var(text)
+    } else {
+        Term::constant(text)
+    }
+}
+
+#[test]
+fn alpha_equivalent_states_are_equal_and_deduplicate() {
+    let a = SymbolicState::new(parse("f(?0.0, ?0.1)"), ConstraintSet::new());
+    let b = SymbolicState::new(parse("f(?7.3, ?2.9)"), ConstraintSet::new());
+    assert_eq!(a, b);
+    let mut set = BTreeSet::new();
+    assert!(set.insert(a));
+    assert!(!set.insert(b));
+    // Different shape is different: a repeated variable is not
+    // alpha-equivalent to distinct variables, and a constant leaf is
+    // neither.
+    let c = SymbolicState::new(parse("f(?0.0, ?0.0)"), ConstraintSet::new());
+    assert!(set.insert(c.clone()));
+    let repeated_renamed = SymbolicState::new(parse("f(?3.7, ?3.7)"), ConstraintSet::new());
+    assert_eq!(c, repeated_renamed);
+    let d = SymbolicState::new(parse("f(?1.0, a)"), ConstraintSet::new());
+    assert_ne!(c, d);
+    assert!(set.insert(d));
+}
+
+#[test]
+fn constraints_distinguish_states() {
+    let plain = SymbolicState::new(parse("f(?0.0)"), ConstraintSet::new());
+    let mut constraints = ConstraintSet::new();
+    constraints.insert(TermConstraint::NotEqual(parse("?0.0"), parse("a")));
+    let constrained = SymbolicState::new(parse("f(?0.0)"), constraints);
+    assert_ne!(plain, constrained);
+    // Alpha-renamed constrained state matches.
+    let mut renamed = ConstraintSet::new();
+    renamed.insert(TermConstraint::NotEqual(parse("?4.2"), parse("a")));
+    let renamed = SymbolicState::new(parse("f(?4.2)"), renamed);
+    assert_eq!(constrained, renamed);
+}
+
+#[test]
+fn config_ceilings_are_fixed_and_enforced() {
+    assert_eq!(InverseSearchConfig::MAX_DEPTH, 64);
+    assert_eq!(InverseSearchConfig::MAX_STATES, 65_536);
+    assert_eq!(InverseSearchConfig::MAX_TRANSITIONS, 262_144);
+    assert_eq!(InverseSearchConfig::MAX_RETAINED_BYTES, 64 * 1024 * 1024);
+    let default = InverseSearchConfig::default();
+    assert_eq!(default.max_states(), InverseSearchConfig::MAX_STATES);
+    // Above-ceiling and zero values are typed errors.
+    assert!(matches!(
+        InverseSearchConfig::new(
+            65, 1_024, 4_096, 4_096, 64, 4_096, 65_536, 1_000_000, 1_024, 1_024
+        ),
+        Err(RewriteError::InvalidLimit { .. })
+    ));
+    assert!(matches!(
+        InverseSearchConfig::new(
+            0, 1_024, 4_096, 4_096, 64, 4_096, 65_536, 1_000_000, 1_024, 1_024
+        ),
+        Err(RewriteError::InvalidLimit { .. })
+    ));
+    assert!(matches!(
+        InverseSearchConfig::new(
+            64, 65_537, 4_096, 4_096, 64, 4_096, 65_536, 1_000_000, 1_024, 1_024
+        ),
+        Err(RewriteError::InvalidLimit { .. })
+    ));
+    assert!(InverseSearchConfig::new(
+        64, 1_024, 4_096, 4_096, 64, 4_096, 65_536, 1_000_000, 1_024, 1_024
+    )
+    .is_ok());
+}
+
+#[test]
+fn search_resources_account_states_transitions_and_bytes() {
+    let config =
+        InverseSearchConfig::new(64, 2, 3, 4_096, 64, 4_096, 65_536, 1_000_000, 8, 1_024).unwrap();
+    let mut resources = SearchResources::new(&config);
+    resources.record_state().unwrap();
+    resources.record_state().unwrap();
+    assert!(matches!(
+        resources.record_state(),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    resources.record_transition().unwrap();
+    resources.record_bytes(8).unwrap();
+    assert!(matches!(
+        resources.record_bytes(1),
+        Err(RewriteError::RelationLimitExceeded { .. })
+    ));
+    assert_eq!(resources.states(), 2);
+    assert_eq!(resources.retained_bytes(), 8);
+}
+
+#[test]
+fn exhausted_requires_certified_authority() {
+    // There is no public constructor for CertifiedExhaustion: the
+    // variant exists but cannot be built from caller data. This test
+    // pins the remaining outcome surface instead.
+    let frontier = amari_rewrite::inverse::BackwardFrontier {
+        states: vec![SymbolicState::new(parse("f(?0.0)"), ConstraintSet::new())],
+        depth_reached: 3,
+    };
+    let outcome = BackwardSearchOutcome::Partial(frontier);
+    assert!(matches!(outcome, BackwardSearchOutcome::Partial(_)));
+    let unsupported =
+        BackwardSearchOutcome::Unsupported(amari_rewrite::inverse::UnsupportedRelation {
+            reason: "theory constraints are not supported in 0.25".to_string(),
+        });
+    assert!(matches!(unsupported, BackwardSearchOutcome::Unsupported(_)));
+}
+
+#[cfg(feature = "serialize")]
+#[test]
+fn strict_serialization_roundtrips() {
+    let state = SymbolicState::new(parse("f(?0.0, a)"), ConstraintSet::new());
+    let json = serde_json::to_string(&state).unwrap();
+    let back: SymbolicState = serde_json::from_str(&json).unwrap();
+    assert_eq!(state, back);
+    // Strict: unknown fields on the config DTO are rejected.
+    let bad = "{\"max_depth\":64,\"max_states\":1024,\"max_transitions\":4096,\"max_term_nodes\":4096,\"max_term_depth\":64,\"max_constraints\":4096,\"max_groundings\":65536,\"max_operations\":1000000,\"max_frontier_bytes\":1024,\"max_trace_bytes\":1024,\"bogus\":1}";
+    assert!(serde_json::from_str::<InverseSearchConfig>(bad).is_err());
+    let config = InverseSearchConfig::default();
+    let json = serde_json::to_string(&config).unwrap();
+    let back: InverseSearchConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, back);
+}


### PR DESCRIPTION
# 0.25 Cohort 3, Task 13: alpha-canonical symbolic search states

Per plan Task 13 and the design's "Backward search" section. The
foundation for the Cohort 3 explorers.

## `SymbolicState` — joint alpha-canonical identity

`{ term, constraints }` where Eq/Ord/Hash route through a **joint**
alpha-canonical digest: one shared first-occurrence renaming pass
across the term AND all constraints (sides canonicalized, encodings
sorted, framed `amari.relation.symbolic-state/v1`). Alpha-equivalent
states deduplicate; constraint differences always distinguish. The
review-caught subtlety: `f(X,X)` vs `f(Y,Z)` are correctly distinct
(repeated vs. distinct variables), and the test suite pins it.

## `InverseSearchConfig` + `SearchResources`

Design-table ceilings as associated constants (65,536 states /
262,144 transitions / depth 64 / 64 MiB retained evidence, plus the
shared term/constraint/operation ceilings). Zero or above-ceiling
caller values → typed `InvalidLimit`. Counters use saturating adds —
no overflow paths.

## `BackwardSearchOutcome` — the honesty guarantee

Five typed variants per the design. **`CertifiedExhaustion` has no
public constructor and private fields** — `Exhausted` can only be
produced with crate-internal certified evidence (fully enumerated
finite domain or exact regular-language exclusion). A depth/node/
operation ceiling can never forge unreachability; it is always
`Partial`. (`certify` is `pub(crate)` with a documented
`allow(dead_code)` until Task 14's explorer becomes the first
production caller.)

## Evidence

RED→GREEN; 5 integration tests + 1 module test. Matrix: default 89,
no-default 90, serialize 95/95, all-features 117 across 25 suites;
MSRV 1.89; clippy `-D warnings` ×2; rustdoc `-D warnings`; catalog
post-fmt (`db89ca1d`, shard 20/20); verifiers PASS.

Next: Task 14 — bounded `BackwardExplorer` (BFS/cost ordering over
these states with per-edge rule/path/unifier/constraint deltas).
